### PR TITLE
fixed cname

### DIFF
--- a/packages/docs/static/CNAME
+++ b/packages/docs/static/CNAME
@@ -1,1 +1,1 @@
-developers.cellix.org
+developers.cellixjs.org


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the static/CNAME file for the docs package