### PR TITLE
Change broadcast method to fire and forget in NodeEventBusImpl

### DIFF
--- a/packages/cellix-event-bus-seedwork-node/src/node-event-bus.ts
+++ b/packages/cellix-event-bus-seedwork-node/src/node-event-bus.ts
@@ -92,7 +92,10 @@ class NodeEventBusImpl implements DomainSeedwork.EventBus {
 					message: `NodeEventBus: Executed ${event.name}`,
 				});
 			} catch (err) {
-				span.setStatus({ code: SpanStatusCode.ERROR });
+				span.setStatus({
+					code: SpanStatusCode.ERROR,
+					message: `NodeEventBus: Error dispatching ${event.name}`,
+				});
 				span.recordException(err as Error);
 			} finally {
 				span.end();

--- a/packages/cellix-event-bus-seedwork-node/src/node-event-bus.ts
+++ b/packages/cellix-event-bus-seedwork-node/src/node-event-bus.ts
@@ -83,7 +83,7 @@ class NodeEventBusImpl implements DomainSeedwork.EventBus {
 			);
 
 			try {
-				await this.broadcaster.broadcast(event.name, {
+				this.broadcaster.broadcast(event.name, {
 					data: JSON.stringify(data),
 					context: contextObject,
 				});


### PR DESCRIPTION
Modify the broadcast method to eliminate the await, allowing for a fire-and-forget approach in event handling.

## Summary by Sourcery

Change the NodeEventBusImpl broadcast method to a fire-and-forget approach and improve error span status messaging.

Enhancements:
- Remove the await from broadcaster.broadcast to enable fire-and-forget event dispatch.
- Include an error message in span.setStatus when dispatching fails for better tracing.