### PR TITLE
fix: update NPM caching and dependency installation steps in build pipeline

### DIFF
--- a/build-pipeline/core/monorepo-build-stage.yml
+++ b/build-pipeline/core/monorepo-build-stage.yml
@@ -71,8 +71,39 @@ stages:
       condition: and(ne(variables.FUNC_TOOLS_CACHE_HIT, 'true'), ne(variables.FUNC_TOOLS_CACHE_HIT, 'inexact'))
       inputs:
         version: '4.2.1'
+        
+    # Cache NPM packages to speed up build process.
+    - task: Cache@2
+      displayName: 'NPM: Restore Cache'
+      condition: and(succeeded(), eq(${{parameters.isNpmCacheAvailable}}, True))
+      inputs:
+        key: 'npm | "$(Agent.OS)" | $(Build.SourcesDirectory)/package-lock.json'
+        restoreKeys: |
+            npm | "$(Agent.OS)"
+        path: ${{parameters.npm_config_cache}}
 
-    # Playwright: Restore browsers cache
+    # Install dependencies
+    - task: Bash@3
+      displayName: 'NPM: Install dependencies'
+      condition: and(succeeded(), eq(${{parameters.isNpmCacheAvailable}}, False))
+      inputs:
+        targetType: 'inline'
+        script: |
+          export NODE_OPTIONS=--max_old_space_size=16384
+          npm install
+        workingDirectory: ''
+
+    - task: Bash@3
+      displayName: 'NPM: Install dependencies using cache'
+      condition: and(succeeded(), eq(${{parameters.isNpmCacheAvailable}}, True))
+      inputs:
+        targetType: 'inline'
+        script: |
+          export NODE_OPTIONS=--max_old_space_size=16384
+          npm ci
+        workingDirectory: ''
+
+        # Playwright: Restore browsers cache
     - task: Cache@2
       displayName: 'Playwright: Restore browsers cache'
       continueOnError: true
@@ -130,37 +161,6 @@ stages:
           find "$(PLAYWRIGHT_BROWSERS_PATH)" -type f -name "headless_shell" -exec chmod +x {} \; 2>/dev/null || true
       env:
         PLAYWRIGHT_BROWSERS_PATH: $(PLAYWRIGHT_BROWSERS_PATH)
-        
-    # Cache NPM packages to speed up build process.
-    - task: Cache@2
-      displayName: 'NPM: Restore Cache'
-      condition: and(succeeded(), eq(${{parameters.isNpmCacheAvailable}}, True))
-      inputs:
-        key: 'npm | "$(Agent.OS)" | $(Build.SourcesDirectory)/package-lock.json'
-        restoreKeys: |
-            npm | "$(Agent.OS)"
-        path: ${{parameters.npm_config_cache}}
-
-    # Install dependencies
-    - task: Bash@3
-      displayName: 'NPM: Install dependencies'
-      condition: and(succeeded(), eq(${{parameters.isNpmCacheAvailable}}, False))
-      inputs:
-        targetType: 'inline'
-        script: |
-          export NODE_OPTIONS=--max_old_space_size=16384
-          npm install
-        workingDirectory: ''
-
-    - task: Bash@3
-      displayName: 'NPM: Install dependencies using cache'
-      condition: and(succeeded(), eq(${{parameters.isNpmCacheAvailable}}, True))
-      inputs:
-        targetType: 'inline'
-        script: |
-          export NODE_OPTIONS=--max_old_space_size=16384
-          npm ci
-        workingDirectory: ''
 
     # Cache Turbo to speed up build process.
     - task: Cache@2

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       "devDependencies": {
         "@amiceli/vitest-cucumber": "^5.1.2",
         "@biomejs/biome": "2.0.0",
+        "@playwright/test": "^1.55.1",
         "@sonar/scan": "^4.3.0",
         "@vitest/coverage-v8": "^3.2.4",
         "azurite": "^3.35.0",
@@ -10354,6 +10355,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -27243,13 +27260,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
-      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.55.0"
+        "playwright-core": "1.55.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -27262,9 +27279,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
-      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -27278,13 +27295,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@amiceli/vitest-cucumber": "^5.1.2",
     "@biomejs/biome": "2.0.0",
+    "@playwright/test": "^1.55.1",
     "@sonar/scan": "^4.3.0",
     "@vitest/coverage-v8": "^3.2.4",
     "azurite": "^3.35.0",


### PR DESCRIPTION
## Summary by Sourcery

Optimize the monorepo build pipeline by consolidating and relocating NPM caching and dependency installation steps with conditional logic and increased memory settings, and add Playwright testing framework as a dev dependency

Enhancements:
- Consolidate and move NPM cache restore and install tasks into a single block in monorepo-build-stage.yml to remove duplication and improve maintainability
- Introduce conditional Bash steps to run npm install or npm ci based on cache availability while setting NODE_OPTIONS to increase memory
- Add @playwright/test to devDependencies to support end-to-end testing