### PR TITLE
chore(codegen): replace npx prettier run in afterAllFileWrite hook with `pnpm exec biome format --write` to fix copilot errors

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm run build
+pnpm run verify


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Swap npx prettier --write for pnpm exec biome format --write in codegen.yml’s afterAllFileWrite hook