### PR TITLE
chore(ci): fix Copilot setup workflow to use pnpm

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -96,6 +96,3 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
-      - name: Authenticate Snyk CLI
-        run: pnpm exec snyk auth $SNYK_TOKEN


### PR DESCRIPTION
## Summary by Sourcery

Switch GitHub Actions Copilot setup to use pnpm for dependency caching and installation

CI:
- Cache pnpm store using pnpm-lock.yaml instead of npm cache
- Install JavaScript dependencies with pnpm install --frozen-lockfile when cache miss
- Invoke Playwright browser installation via pnpm exec instead of npx