### PR TITLE
Add outputs for storage account in Bicep module and build script in package.json

### DIFF
--- a/iac/storage-account/main.bicep
+++ b/iac/storage-account/main.bicep
@@ -117,3 +117,6 @@ module tableService './table-service.bicep' = if(enableTableService) {
     tables: tables
   }
 }
+
+output storageAccountName string = storageAccount.outputs.storageAccountName
+output storageAccountId string = storageAccount.outputs.storageAccountId

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"antd": "antd",
 		"audit": "(pnpm audit --audit-level=high --prod) && (pnpm audit --audit-level=critical --dev)",
 		"build": "turbo run build",
+        "build:iac": "node build-pipeline/scripts/build-bicep.js",
 		"test": "turbo run test",
 		"lint": "turbo run lint",
 		"dev": "pnpm proxy:stop && pnpm proxy:start && turbo watch azurite dev --filter='./apps/*' --filter='./packages/*'",

--- a/packages/cellix/archunit-tests/package.json
+++ b/packages/cellix/archunit-tests/package.json
@@ -43,8 +43,8 @@
 	},
 	"scripts": {
 		"prebuild": "biome lint",
-		"build": "tsc --build",
-		"watch": "tsc --watch",
+		"build": "tsgo --build",
+		"watch": "tsgo --watch",
 		"test": "vitest run",
 		"test:arch": "vitest run",
 		"test:coverage": "pnpm run test",


### PR DESCRIPTION
Introduce outputs for the storage account name and ID in the Bicep module. Include a build script for Bicep in the package.json to streamline the build process.

## Summary by Sourcery

Expose storage account outputs from the Bicep storage-account module and add a dedicated IaC build script to the package.json scripts.

New Features:
- Export storage account name and resource ID as outputs from the storage-account Bicep module.

Build:
- Add a build:iac npm script to run the Bicep build pipeline via Node.