### PR TITLE
Add support for oidcConfigName in mock oauth2 server user definitions

### DIFF
--- a/apps/docs/deploy-docs.yml
+++ b/apps/docs/deploy-docs.yml
@@ -31,7 +31,7 @@ jobs:
               echo "Installing PNPM..."
               npm install --global corepack@latest
               corepack enable
-              corepack prepare pnpm@11.0.8 --activate
+              corepack prepare pnpm@11.9.0 --activate
               pnpm config set store-dir $(Pipeline.Workspace)/.pnpm-store
         - download: current
           displayName: 'Artifact: Download Docs package'

--- a/apps/server-oauth2-mock/src/index.ts
+++ b/apps/server-oauth2-mock/src/index.ts
@@ -30,7 +30,7 @@ try {
 	const manager = createMockOAuth2Manager({ port, host: '127.0.0.1', baseUrl: normalizeBaseUrl(baseUrl) });
 
 	for (const portal of portals) {
-		const userStore = createFileUserStore(path.join(appsDir, portal.dirName));
+		const userStore = createFileUserStore(path.join(appsDir, portal.dirName), portal.configName);
 		const config: MockOAuth2PortalConfig = {
 			allowedRedirectUris: new Set([portal.redirectUri]),
 			allowedRedirectUri: portal.redirectUri,

--- a/apps/ui-community/mock-oidc.users.json
+++ b/apps/ui-community/mock-oidc.users.json
@@ -3,6 +3,7 @@
 		"username": "test@example.com",
 		"sub": "00000000-0000-4000-8000-000000000001",
 		"password": "password",
+        "oidcConfigName": "end-user",
 		"claims": {
 			"email": "test@example.com",
 			"given_name": "Test",
@@ -14,6 +15,7 @@
 		"username": "john.doe@example.com",
 		"sub": "00000000-0000-4000-8000-000000000002",
 		"password": "password",
+        "oidcConfigName": "end-user",
 		"claims": {
 			"email": "john.doe@example.com",
 			"given_name": "John",
@@ -25,6 +27,7 @@
 		"username": "owner@test.example",
 		"sub": "aaaaaaaa-bbbb-1ccc-9ddd-eeeeeeeeee01",
 		"password": "password",
+        "oidcConfigName": "end-user",
 		"claims": {
 			"email": "owner@test.example",
 			"given_name": "Test",

--- a/apps/ui-staff/mock-oidc.users.json
+++ b/apps/ui-staff/mock-oidc.users.json
@@ -3,6 +3,7 @@
 		"username": "staff@ownercommunity.onmicrosoft.com",
 		"sub": "10000000-0000-4000-8000-000000000001",
 		"password": "password",
+        "oidcConfigName": "staff-user",
 		"claims": {
 			"email": "staff@ownercommunity.onmicrosoft.com",
 			"given_name": "Staff",

--- a/build-pipeline/core/monorepo-build-stage.yml
+++ b/build-pipeline/core/monorepo-build-stage.yml
@@ -99,7 +99,7 @@ stages:
           echo "Installing PNPM..."
           npm install --global corepack@latest
           corepack enable
-          corepack prepare pnpm@11.0.8 --activate
+          corepack prepare pnpm@11.9.0 --activate
           pnpm config set store-dir ${{parameters.pnpm_config_cache}}
           pnpm --version
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"author": "CellixJs",
 	"license": "MIT",
-	"packageManager": "pnpm@11.0.8",
+	"packageManager": "pnpm@11.9.0",
 	"scripts": {
 		"antd": "antd",
 		"install:all": "pnpm i && pnpm run install:python",

--- a/packages/cellix/server-oauth2-mock-seedwork/src/file-user-store.ts
+++ b/packages/cellix/server-oauth2-mock-seedwork/src/file-user-store.ts
@@ -21,21 +21,26 @@ import type { MockOAuth2User, MockOAuth2UserStore } from './types.ts';
  * - File contents are cached by `mtime` to avoid redundant disk reads on the request path.
  * - The overlay file is written with mode `0o600` (owner-readable only) to protect plaintext passwords.
  * - On startup, the store eagerly preloads both files and logs the combined user count.
+ * - When `oidcConfigName` is provided, only users whose `oidcConfigName` matches (or is absent) are
+ *   returned. Users with a different `oidcConfigName` are invisible to this store instance.
  *
  * @param appDir - Absolute path to the application directory that owns the user store files
  *   (typically the `ui-*` app directory, e.g. `/repo/apps/ui-community`).
+ * @param oidcConfigName - Optional OIDC config name (the `name` field from `mock-oidc.json`,
+ *   e.g. `"end-user"`). When provided, filters users to those whose `oidcConfigName` matches
+ *   this value or is absent. When omitted, all users from the store files are visible.
  * @returns A {@link MockOAuth2UserStore} backed by the two JSON files in `appDir`.
  *
  * @example
  * ```ts
  * import { createFileUserStore } from '@cellix/server-oauth2-mock-seedwork';
  *
- * const store = createFileUserStore('/repo/apps/ui-community');
+ * const store = createFileUserStore('/repo/apps/ui-community', 'end-user');
  * const users = await store.listUsers();
  * await store.addUser({ username: 'alice', sub: 'sub-alice', password: 'secret' });
  * ```
  */
-export function createFileUserStore(appDir: string): MockOAuth2UserStore {
+export function createFileUserStore(appDir: string, oidcConfigName?: string): MockOAuth2UserStore {
 	const committedPath = path.join(appDir, 'mock-oidc.users.json');
 	const localPath = path.join(appDir, 'mock-oidc.users.local.json');
 
@@ -135,6 +140,7 @@ export function createFileUserStore(appDir: string): MockOAuth2UserStore {
 				sub?: unknown;
 				claims?: unknown;
 				password?: unknown;
+				oidcConfigName?: unknown;
 			};
 
 			const username = e.username;
@@ -176,11 +182,21 @@ export function createFileUserStore(appDir: string): MockOAuth2UserStore {
 				password = e.password;
 			}
 
+			let userOidcConfigName: string | undefined;
+			if (e.oidcConfigName !== undefined) {
+				if (typeof e.oidcConfigName !== 'string') {
+					console.warn(`[server-oauth2-mock] Invalid user entry in ${filePath} for "${username}": "oidcConfigName" must be a string if present, skipping`);
+					continue;
+				}
+				userOidcConfigName = e.oidcConfigName;
+			}
+
 			const user: MockOAuth2User = {
 				username,
 				sub,
 				...(claims ? { claims } : {}),
 				...(password ? { password } : {}),
+				...(userOidcConfigName !== undefined ? { oidcConfigName: userOidcConfigName } : {}),
 			};
 
 			out.push(user);
@@ -216,7 +232,9 @@ export function createFileUserStore(appDir: string): MockOAuth2UserStore {
 			seenSubs.add(u.sub);
 			out.push(u);
 		}
-		return out;
+		if (oidcConfigName === undefined) return out;
+		// Filter to users that belong to this OIDC config or have no oidcConfigName (visible to all configs)
+		return out.filter((u) => u.oidcConfigName === undefined || u.oidcConfigName === oidcConfigName);
 	}
 
 	// persistOverlayUnsafe performs the actual write to disk and updates the cache.

--- a/packages/cellix/server-oauth2-mock-seedwork/src/portal-discovery.ts
+++ b/packages/cellix/server-oauth2-mock-seedwork/src/portal-discovery.ts
@@ -60,6 +60,12 @@ export interface PortalOidcConfig {
 	name: string;
 	/** The originating `ui-*` directory name (e.g. `ui-community`). */
 	dirName: string;
+	/**
+	 * The original config name from `mock-oidc.json` before the registration name is computed
+	 * (e.g. `end-user` from `{ "name": "end-user", ... }`).
+	 * Used to filter mock users by their `oidcConfigName` field.
+	 */
+	configName: string;
 	/** Resolved OAuth2 client identifier read from the app's `.env` or `process.env`. */
 	clientId: string;
 	/** Resolved OAuth2 redirect URI read from the app's `.env` or `process.env`. */
@@ -244,7 +250,7 @@ function buildPortalFromConfig(config: MockOidcConfig, parsedEnv: Record<string,
 		return null;
 	}
 
-	const base = { name: config.name, dirName: entryName, clientId, redirectUri };
+	const base = { name: config.name, dirName: entryName, configName: config.name, clientId, redirectUri };
 	if (config.claims !== undefined) return { ...base, claims: config.claims };
 	return base;
 }

--- a/packages/cellix/server-oauth2-mock-seedwork/src/types.ts
+++ b/packages/cellix/server-oauth2-mock-seedwork/src/types.ts
@@ -18,6 +18,15 @@ export interface MockOAuth2User {
 	password?: string;
 	/** Arbitrary claims associated with this user (email, given_name, etc) */
 	claims?: Record<string, unknown>;
+	/**
+	 * Name of the OIDC config (from `mock-oidc.json`) that this user belongs to.
+	 * When set, the user is only visible to the matching OIDC config registration.
+	 * When absent, the user is visible to all OIDC config registrations for the portal.
+	 *
+	 * Matches the `name` field of the corresponding entry in `mock-oidc.json`
+	 * (e.g. `"end-user"` or `"staff-user"`), not the computed registration name.
+	 */
+	oidcConfigName?: string;
 }
 
 /**

--- a/packages/cellix/server-oauth2-mock-seedwork/tests/file-user-store.test.ts
+++ b/packages/cellix/server-oauth2-mock-seedwork/tests/file-user-store.test.ts
@@ -8,6 +8,10 @@ function makeTempDir() {
 	return fs.mkdtempSync(path.join(os.tmpdir(), 'server-oauth2-mock-users-'));
 }
 
+function writeUsers(dir: string, filename: string, users: unknown[]) {
+	fs.writeFileSync(path.join(dir, filename), JSON.stringify(users, null, 2), 'utf-8');
+}
+
 describe('file user store concurrency', () => {
 	let tmp: string | null = null;
 	beforeEach(() => {
@@ -36,5 +40,119 @@ describe('file user store concurrency', () => {
 		await Promise.all([addPromise, persistPromise]);
 		const users = await store.listUsers();
 		expect(users.find((u) => u.username === 'bob')).toBeDefined();
+	});
+});
+
+describe('file user store oidcConfigName filtering', () => {
+	let tmp: string | null = null;
+	beforeEach(() => {
+		tmp = makeTempDir();
+	});
+	afterEach(() => {
+		if (tmp && fs.existsSync(tmp)) {
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+		tmp = null;
+	});
+
+	it('returns all users when no oidcConfigName is provided to createFileUserStore', async () => {
+		if (!tmp) throw new Error('tmp not created');
+		writeUsers(tmp, 'mock-oidc.users.json', [
+			{ username: 'end-user@example.com', sub: 'sub-end', oidcConfigName: 'end-user' },
+			{ username: 'staff@example.com', sub: 'sub-staff', oidcConfigName: 'staff-user' },
+			{ username: 'shared@example.com', sub: 'sub-shared' },
+		]);
+		const store = createFileUserStore(tmp);
+		const users = await store.listUsers();
+		expect(users).toHaveLength(3);
+	});
+
+	it('filters to users with matching oidcConfigName or no oidcConfigName', async () => {
+		if (!tmp) throw new Error('tmp not created');
+		writeUsers(tmp, 'mock-oidc.users.json', [
+			{ username: 'end-user@example.com', sub: 'sub-end', oidcConfigName: 'end-user' },
+			{ username: 'staff@example.com', sub: 'sub-staff', oidcConfigName: 'staff-user' },
+			{ username: 'shared@example.com', sub: 'sub-shared' },
+		]);
+		const store = createFileUserStore(tmp, 'end-user');
+		const users = await store.listUsers();
+		expect(users).toHaveLength(2);
+		expect(users.find((u) => u.username === 'end-user@example.com')).toBeDefined();
+		expect(users.find((u) => u.username === 'shared@example.com')).toBeDefined();
+		expect(users.find((u) => u.username === 'staff@example.com')).toBeUndefined();
+	});
+
+	it('excludes users from a different oidcConfigName', async () => {
+		if (!tmp) throw new Error('tmp not created');
+		writeUsers(tmp, 'mock-oidc.users.json', [
+			{ username: 'end@example.com', sub: 'sub-end', oidcConfigName: 'end-user' },
+			{ username: 'staff@example.com', sub: 'sub-staff', oidcConfigName: 'staff-user' },
+		]);
+		const endStore = createFileUserStore(tmp, 'end-user');
+		const staffStore = createFileUserStore(tmp, 'staff-user');
+
+		const endUsers = await endStore.listUsers();
+		expect(endUsers).toHaveLength(1);
+		expect(endUsers[0]?.username).toBe('end@example.com');
+
+		const staffUsers = await staffStore.listUsers();
+		expect(staffUsers).toHaveLength(1);
+		expect(staffUsers[0]?.username).toBe('staff@example.com');
+	});
+
+	it('findByUsername respects oidcConfigName filter', async () => {
+		if (!tmp) throw new Error('tmp not created');
+		writeUsers(tmp, 'mock-oidc.users.json', [
+			{ username: 'end@example.com', sub: 'sub-end', oidcConfigName: 'end-user' },
+			{ username: 'staff@example.com', sub: 'sub-staff', oidcConfigName: 'staff-user' },
+		]);
+		const endStore = createFileUserStore(tmp, 'end-user');
+
+		expect(await endStore.findByUsername('end@example.com')).toBeDefined();
+		expect(await endStore.findByUsername('staff@example.com')).toBeUndefined();
+	});
+
+	it('findBySub respects oidcConfigName filter', async () => {
+		if (!tmp) throw new Error('tmp not created');
+		writeUsers(tmp, 'mock-oidc.users.json', [
+			{ username: 'end@example.com', sub: 'sub-end', oidcConfigName: 'end-user' },
+			{ username: 'staff@example.com', sub: 'sub-staff', oidcConfigName: 'staff-user' },
+		]);
+		const staffStore = createFileUserStore(tmp, 'staff-user');
+
+		expect(await staffStore.findBySub('sub-staff')).toBeDefined();
+		expect(await staffStore.findBySub('sub-end')).toBeUndefined();
+	});
+
+	it('users without oidcConfigName are visible to all scoped stores', async () => {
+		if (!tmp) throw new Error('tmp not created');
+		writeUsers(tmp, 'mock-oidc.users.json', [
+			{ username: 'shared@example.com', sub: 'sub-shared' },
+		]);
+		const endStore = createFileUserStore(tmp, 'end-user');
+		const staffStore = createFileUserStore(tmp, 'staff-user');
+
+		expect(await endStore.findByUsername('shared@example.com')).toBeDefined();
+		expect(await staffStore.findByUsername('shared@example.com')).toBeDefined();
+	});
+
+	it('skips user entry with non-string oidcConfigName and warns', async () => {
+		if (!tmp) throw new Error('tmp not created');
+		const warnSpy: unknown[] = [];
+		const origWarn = console.warn;
+		console.warn = (...args: unknown[]) => warnSpy.push(args);
+		try {
+			writeUsers(tmp, 'mock-oidc.users.json', [
+				{ username: 'bad@example.com', sub: 'sub-bad', oidcConfigName: 123 },
+				{ username: 'good@example.com', sub: 'sub-good' },
+			]);
+			const store = createFileUserStore(tmp);
+			const users = await store.listUsers();
+			expect(users).toHaveLength(1);
+			expect(users[0]?.username).toBe('good@example.com');
+			expect(warnSpy.length).toBeGreaterThan(0);
+		} finally {
+			console.warn = origWarn;
+		}
 	});
 });

--- a/packages/cellix/server-oauth2-mock-seedwork/tests/file-user-store.test.ts
+++ b/packages/cellix/server-oauth2-mock-seedwork/tests/file-user-store.test.ts
@@ -136,6 +136,46 @@ describe('file user store oidcConfigName filtering', () => {
 		expect(await staffStore.findByUsername('shared@example.com')).toBeDefined();
 	});
 
+	it('applies oidcConfigName filtering across base and overlay files', async () => {
+		if (!tmp) throw new Error('tmp not created');
+		writeUsers(tmp, 'mock-oidc.users.json', [
+			{ username: 'base-alice', sub: 'sub-base-alice', oidcConfigName: 'config-a' },
+			{ username: 'base-bob', sub: 'sub-base-bob', oidcConfigName: 'config-b' },
+		]);
+		writeUsers(tmp, 'mock-oidc.users.local.json', [
+			{ username: 'overlay-charlie', sub: 'sub-overlay-charlie', oidcConfigName: 'config-a' },
+			// No oidcConfigName: visible to all scoped stores per documented behavior
+			{ username: 'overlay-dave', sub: 'sub-overlay-dave' },
+		]);
+
+		const store = createFileUserStore(tmp, 'config-a');
+		const users = await store.listUsers();
+		const usernames = users.map((u) => u.username).sort();
+
+		// base-alice (config-a) and overlay-charlie (config-a) match; overlay-dave (no oidcConfigName) is shared
+		expect(usernames).toEqual(['base-alice', 'overlay-charlie', 'overlay-dave'].sort());
+		// base-bob belongs to config-b and must not appear
+		expect(usernames).not.toContain('base-bob');
+	});
+
+	it('merges overlay and base users when no oidcConfigName filter is provided', async () => {
+		if (!tmp) throw new Error('tmp not created');
+		writeUsers(tmp, 'mock-oidc.users.json', [
+			{ username: 'base-alice', sub: 'sub-base-alice', oidcConfigName: 'config-a' },
+			{ username: 'base-bob', sub: 'sub-base-bob', oidcConfigName: 'config-b' },
+		]);
+		writeUsers(tmp, 'mock-oidc.users.local.json', [
+			{ username: 'overlay-charlie', sub: 'sub-overlay-charlie', oidcConfigName: 'config-a' },
+			{ username: 'overlay-dave', sub: 'sub-overlay-dave' },
+		]);
+
+		const store = createFileUserStore(tmp);
+		const users = await store.listUsers();
+		const usernames = users.map((u) => u.username).sort();
+
+		expect(usernames).toEqual(['base-alice', 'base-bob', 'overlay-charlie', 'overlay-dave'].sort());
+	});
+
 	it('skips user entry with non-string oidcConfigName and warns', async () => {
 		if (!tmp) throw new Error('tmp not created');
 		const warnSpy: unknown[] = [];
@@ -151,6 +191,15 @@ describe('file user store oidcConfigName filtering', () => {
 			expect(users).toHaveLength(1);
 			expect(users[0]?.username).toBe('good@example.com');
 			expect(warnSpy.length).toBeGreaterThan(0);
+			expect(
+				warnSpy.some((args) =>
+					(args as unknown[]).some(
+						(arg) =>
+							typeof arg === 'string' &&
+							arg.includes('"oidcConfigName" must be a string'),
+					),
+				),
+			).toBe(true);
 		} finally {
 			console.warn = origWarn;
 		}

--- a/packages/cellix/server-oauth2-mock-seedwork/tests/portal-discovery.test.ts
+++ b/packages/cellix/server-oauth2-mock-seedwork/tests/portal-discovery.test.ts
@@ -57,6 +57,11 @@ describe('discoverPortalConfigs', () => {
 		expect(portals.length).toBe(2);
 		const names = portals.map((p) => p.name).sort((a, b) => a.localeCompare(b));
 		expect(names).toEqual(['a-a', 'b-b']);
+		// configName should be the original config.name from mock-oidc.json
+		const pa = portals.find((p) => p.name === 'a-a');
+		const pb = portals.find((p) => p.name === 'b-b');
+		expect(pa?.configName).toBe('a');
+		expect(pb?.configName).toBe('b');
 	});
 
 	it('supports multi-config mock-oidc.json arrays and resolves envs per element', () => {
@@ -98,6 +103,9 @@ describe('discoverPortalConfigs', () => {
 		expect(end?.redirectUri).toBe('https://community/end/cb');
 		expect(staff?.clientId).toBe('staff-cid');
 		expect(staff?.redirectUri).toBe('https://community/staff/cb');
+		// configName is the original name from mock-oidc.json, not the computed registration name
+		expect(end?.configName).toBe('end-user');
+		expect(staff?.configName).toBe('staff-user');
 	});
 
 	it('handles partially invalid mock-oidc.json arrays and skips only invalid elements', () => {
@@ -546,6 +554,38 @@ describe('discoverPortalConfigs', () => {
 		} finally {
 			warnSpy.mockRestore();
 		}
+	});
+
+	it('sets configName to the original config.name, distinct from the computed registration name', () => {
+		if (!tmp) throw new Error('tmp not created');
+
+		writeJson(tmp, 'ui-portal/mock-oidc.json', [
+			{
+				name: 'end-user',
+				envVars: { clientId: 'VITE_APP_PORTAL_END_CLIENTID', redirectUri: 'VITE_APP_PORTAL_END_REDIRECT' },
+			},
+			{
+				name: 'staff-user',
+				envVars: { clientId: 'VITE_APP_PORTAL_STAFF_CLIENTID', redirectUri: 'VITE_APP_PORTAL_STAFF_REDIRECT' },
+			},
+		]);
+		writeEnv(
+			tmp,
+			'ui-portal/.env',
+			'VITE_APP_PORTAL_END_CLIENTID=end-cid\nVITE_APP_PORTAL_END_REDIRECT=https://portal/end/cb\nVITE_APP_PORTAL_STAFF_CLIENTID=staff-cid\nVITE_APP_PORTAL_STAFF_REDIRECT=https://portal/staff/cb\n',
+		);
+
+		const portals = discoverPortalConfigs(tmp);
+		expect(portals).toHaveLength(2);
+
+		const end = portals.find((p) => p.name === 'portal-end-user');
+		const staff = portals.find((p) => p.name === 'portal-staff-user');
+
+		// registration name includes the dir prefix; configName is just the original name
+		expect(end?.name).toBe('portal-end-user');
+		expect(end?.configName).toBe('end-user');
+		expect(staff?.name).toBe('portal-staff-user');
+		expect(staff?.configName).toBe('staff-user');
 	});
 
 	it('warns for non-conforming env var names but still resolves them', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,7 +162,7 @@ overrides:
   postcss: 8.5.10
   protobufjs: 7.6.3
   ip-address: ^10.1.1
-  fast-uri: ^3.1.2
+  fast-uri: ^4.0.1
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@babel/core': ^7.29.6
   js-yaml@4.1.1: 4.2.0
@@ -210,7 +210,7 @@ importers:
         version: link:packages/cellix/graphql-codegen
       '@graphql-codegen/cli':
         specifier: ^5.0.7
-        version: 5.0.7(@parcel/watcher@2.5.1)(@types/node@22.19.15)(graphql@16.12.0)(typescript@6.0.3)
+        version: 5.0.7(@parcel/watcher@2.5.1)(@types/node@22.19.15)(graphql@16.12.0)(supports-color@8.1.1)(typescript@6.0.3)
       '@graphql-codegen/introspection':
         specifier: ^4.0.3
         version: 4.0.3(graphql@16.12.0)
@@ -243,7 +243,7 @@ importers:
         version: 7.0.0-dev.20260428.1
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
-        version: 4.1.8(vitest@4.1.8)
+        version: 4.1.8(supports-color@8.1.1)(vitest@4.1.8)
       chrome-devtools-mcp:
         specifier: ^1.3.0
         version: 1.3.0
@@ -349,7 +349,7 @@ importers:
         version: 2.1.63
       azurite:
         specifier: ^3.35.0
-        version: 3.35.0
+        version: 3.35.0(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
@@ -449,7 +449,7 @@ importers:
         version: 6.18.0
       mongoose:
         specifier: 'catalog:'
-        version: 8.17.0
+        version: 8.17.0(supports-color@8.1.1)
     devDependencies:
       '@cellix/config-typescript':
         specifier: workspace:*
@@ -933,10 +933,10 @@ importers:
         version: 6.18.0
       mongodb-memory-server:
         specifier: ^10.1.4
-        version: 10.3.0
+        version: 10.3.0(supports-color@8.1.1)
       mongoose:
         specifier: 'catalog:'
-        version: 8.17.0
+        version: 8.17.0(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
@@ -951,7 +951,7 @@ importers:
     dependencies:
       '@apollo/server':
         specifier: 'catalog:'
-        version: 5.5.0(graphql@16.12.0)
+        version: 5.5.0(graphql@16.12.0)(supports-color@8.1.1)
       '@cellix/server-mongodb-memory-mock-seedwork':
         specifier: workspace:*
         version: link:../server-mongodb-memory-mock-seedwork
@@ -1024,7 +1024,7 @@ importers:
         version: 10.3.0
       mongoose:
         specifier: 'catalog:'
-        version: 8.17.0
+        version: 8.17.0(supports-color@8.1.1)
     devDependencies:
       '@cellix/config-typescript':
         specifier: workspace:*
@@ -1572,7 +1572,7 @@ importers:
         version: link:../../cellix/mongoose-seedwork
       mongoose:
         specifier: 'catalog:'
-        version: 8.17.0
+        version: 8.17.0(supports-color@8.1.1)
     devDependencies:
       '@cellix/archunit-tests':
         specifier: workspace:*
@@ -1723,7 +1723,7 @@ importers:
     dependencies:
       '@apollo/server':
         specifier: 'catalog:'
-        version: 5.5.0(graphql@16.12.0)
+        version: 5.5.0(graphql@16.12.0)(supports-color@8.1.1)
       '@apollo/utils.withrequired':
         specifier: ^3.0.0
         version: 3.0.0
@@ -1784,7 +1784,7 @@ importers:
         version: 6.18.0
       mongoose:
         specifier: 'catalog:'
-        version: 8.17.0
+        version: 8.17.0(supports-color@8.1.1)
     devDependencies:
       '@cellix/archunit-tests':
         specifier: workspace:*
@@ -1834,7 +1834,7 @@ importers:
     dependencies:
       '@apollo/server':
         specifier: 'catalog:'
-        version: 5.5.0(graphql@16.12.0)
+        version: 5.5.0(graphql@16.12.0)(supports-color@8.1.1)
       '@cellix/api-services-spec':
         specifier: workspace:*
         version: link:../../cellix/api-services-spec
@@ -1908,7 +1908,7 @@ importers:
         version: link:../../cellix/mongoose-seedwork
       mongoose:
         specifier: 'catalog:'
-        version: 8.17.0
+        version: 8.17.0(supports-color@8.1.1)
     devDependencies:
       '@cellix/config-typescript':
         specifier: workspace:*
@@ -9046,8 +9046,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@4.0.1:
+    resolution: {integrity: sha512-j0VntHrljgRKiWdbjL1xECG44OQu5sb7en4b8z2CcRvtDUEG5DAvkXlllrRhvbABR+m2mUiSgYBPvDj/PzB0dg==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -12469,9 +12469,6 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sax@1.4.3:
-    resolution: {integrity: sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==}
-
   sax@1.5.0:
     resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
     engines: {node: '>=11.0.0'}
@@ -14353,7 +14350,7 @@ snapshots:
       '@apollo/utils.logger': 3.0.0
       graphql: 16.12.0
 
-  '@apollo/server@5.5.0(graphql@16.12.0)':
+  '@apollo/server@5.5.0(graphql@16.12.0)(supports-color@8.1.1)':
     dependencies:
       '@apollo/cache-control-types': 1.0.3(graphql@16.12.0)
       '@apollo/server-gateway-interface': 2.0.0(graphql@16.12.0)
@@ -14367,10 +14364,10 @@ snapshots:
       '@apollo/utils.withrequired': 3.0.0
       '@graphql-tools/schema': 10.0.30(graphql@16.12.0)
       async-retry: 1.3.3
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@8.1.1)
       content-type: 1.0.5
       cors: 2.8.5
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       graphql: 16.12.0
       loglevel: 1.9.2
       lru-cache: 11.3.5
@@ -14787,7 +14784,7 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.6':
+  '@babel/core@7.29.6(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -14796,7 +14793,7 @@ snapshots:
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -14845,27 +14842,27 @@ snapshots:
 
   '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.6)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -14880,31 +14877,31 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14918,25 +14915,25 @@ snapshots:
 
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-replace-supers@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -14956,7 +14953,7 @@ snapshots:
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -14976,25 +14973,25 @@ snapshots:
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.6)
@@ -15003,64 +15000,64 @@ snapshots:
 
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6)
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6)
@@ -15069,17 +15066,17 @@ snapshots:
 
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -15087,7 +15084,7 @@ snapshots:
 
   '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -15095,55 +15092,55 @@ snapshots:
 
   '@babel/plugin-transform-classes@7.28.4(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.6)
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.29.7
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
     transitivePeerDependencies:
@@ -15151,17 +15148,17 @@ snapshots:
 
   '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -15169,36 +15166,36 @@ snapshots:
 
   '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -15206,7 +15203,7 @@ snapshots:
 
   '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -15214,17 +15211,17 @@ snapshots:
 
   '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -15232,39 +15229,39 @@ snapshots:
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6)
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.6)
     transitivePeerDependencies:
@@ -15272,12 +15269,12 @@ snapshots:
 
   '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -15285,12 +15282,12 @@ snapshots:
 
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -15298,7 +15295,7 @@ snapshots:
 
   '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
@@ -15307,29 +15304,29 @@ snapshots:
 
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
@@ -15340,29 +15337,29 @@ snapshots:
 
   '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-runtime@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.6)
@@ -15374,12 +15371,12 @@ snapshots:
 
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-spread@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -15387,22 +15384,22 @@ snapshots:
 
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
@@ -15413,31 +15410,31 @@ snapshots:
 
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/preset-env@7.28.5(@babel/core@7.29.6)':
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
@@ -15512,14 +15509,14 @@ snapshots:
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/preset-react@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
       '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.6)
@@ -15531,7 +15528,7 @@ snapshots:
 
   '@babel/preset-typescript@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.6)
@@ -15572,7 +15569,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -15962,11 +15959,11 @@ snapshots:
       '@cucumber/ci-environment': 13.0.0
       '@cucumber/cucumber-expressions': 19.0.0
       '@cucumber/gherkin': 38.0.0
-      '@cucumber/gherkin-streams': 6.0.0(@cucumber/gherkin@38.0.0)(@cucumber/message-streams@4.1.1(@cucumber/messages@32.2.0))(@cucumber/messages@32.2.0)
+      '@cucumber/gherkin-streams': 6.0.0(@cucumber/gherkin@38.0.0)(@cucumber/message-streams@4.1.1(@cucumber/messages@32.3.1))(@cucumber/messages@32.2.0)
       '@cucumber/gherkin-utils': 11.0.0
       '@cucumber/html-formatter': 23.0.0(@cucumber/messages@32.2.0)
       '@cucumber/junit-xml-formatter': 0.13.3(@cucumber/messages@32.2.0)
-      '@cucumber/message-streams': 4.1.1(@cucumber/messages@32.2.0)
+      '@cucumber/message-streams': 4.1.1(@cucumber/messages@32.3.1)
       '@cucumber/messages': 32.2.0
       '@cucumber/pretty-formatter': 1.0.1(@cucumber/cucumber@12.8.1)(@cucumber/messages@32.2.0)
       '@cucumber/tag-expressions': 9.1.0
@@ -15999,10 +15996,10 @@ snapshots:
       yaml: 2.8.3
       yup: 1.7.1
 
-  '@cucumber/gherkin-streams@6.0.0(@cucumber/gherkin@38.0.0)(@cucumber/message-streams@4.1.1(@cucumber/messages@32.2.0))(@cucumber/messages@32.2.0)':
+  '@cucumber/gherkin-streams@6.0.0(@cucumber/gherkin@38.0.0)(@cucumber/message-streams@4.1.1(@cucumber/messages@32.3.1))(@cucumber/messages@32.2.0)':
     dependencies:
       '@cucumber/gherkin': 38.0.0
-      '@cucumber/message-streams': 4.1.1(@cucumber/messages@32.2.0)
+      '@cucumber/message-streams': 4.1.1(@cucumber/messages@32.3.1)
       '@cucumber/messages': 32.2.0
       commander: 14.0.0
       source-map-support: 0.5.21
@@ -16051,9 +16048,9 @@ snapshots:
       luxon: 3.7.2
       xmlbuilder: 15.1.1
 
-  '@cucumber/message-streams@4.1.1(@cucumber/messages@32.2.0)':
+  '@cucumber/message-streams@4.1.1(@cucumber/messages@32.3.1)':
     dependencies:
-      '@cucumber/messages': 32.2.0
+      '@cucumber/messages': 32.3.1
       mime: 3.0.0
 
   '@cucumber/messages@26.0.1':
@@ -16163,7 +16160,7 @@ snapshots:
 
   '@docusaurus/babel@3.10.1(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/generator': 7.29.1
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.6)
       '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.29.6)
@@ -16188,7 +16185,7 @@ snapshots:
 
   '@docusaurus/bundler@3.10.1(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.3)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@docusaurus/babel': 3.10.1(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@docusaurus/cssnano-preset': 3.10.1
       '@docusaurus/logger': 3.10.1
@@ -17038,7 +17035,7 @@ snapshots:
       graphql: 16.12.0
       tslib: 2.6.3
 
-  '@graphql-codegen/cli@5.0.7(@parcel/watcher@2.5.1)(@types/node@22.19.15)(graphql@16.12.0)(typescript@6.0.3)':
+  '@graphql-codegen/cli@5.0.7(@parcel/watcher@2.5.1)(@types/node@22.19.15)(graphql@16.12.0)(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/template': 7.27.2
@@ -17053,7 +17050,7 @@ snapshots:
       '@graphql-tools/graphql-file-loader': 8.1.8(graphql@16.12.0)
       '@graphql-tools/json-file-loader': 8.0.25(graphql@16.12.0)
       '@graphql-tools/load': 8.1.7(graphql@16.12.0)
-      '@graphql-tools/prisma-loader': 8.0.17(@types/node@22.19.15)(graphql@16.12.0)
+      '@graphql-tools/prisma-loader': 8.0.17(@types/node@22.19.15)(graphql@16.12.0)(supports-color@8.1.1)
       '@graphql-tools/url-loader': 8.0.33(@types/node@22.19.15)(graphql@16.12.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       '@whatwg-node/fetch': 0.10.13
@@ -17388,7 +17385,7 @@ snapshots:
 
   '@graphql-tools/graphql-tag-pluck@8.3.26(graphql@16.12.0)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/parser': 7.29.2
       '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.6)
       '@babel/traverse': 7.29.0
@@ -17442,7 +17439,7 @@ snapshots:
       graphql: 16.12.0
       tslib: 2.8.1
 
-  '@graphql-tools/prisma-loader@8.0.17(@types/node@22.19.15)(graphql@16.12.0)':
+  '@graphql-tools/prisma-loader@8.0.17(@types/node@22.19.15)(graphql@16.12.0)(supports-color@8.1.1)':
     dependencies:
       '@graphql-tools/url-loader': 8.0.33(@types/node@22.19.15)(graphql@16.12.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
@@ -19316,39 +19313,39 @@ snapshots:
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
   '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
   '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
   '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
   '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
   '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
   '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
   '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
   '@svgr/babel-preset@8.1.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.6)
       '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.6)
       '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.6)
@@ -19360,7 +19357,7 @@ snapshots:
 
   '@svgr/core@8.1.0(typescript@6.0.3)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.6)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@6.0.3)
@@ -19376,7 +19373,7 @@ snapshots:
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.6)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
@@ -19395,7 +19392,7 @@ snapshots:
 
   '@svgr/webpack@8.1.0(typescript@6.0.3)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.29.6)
       '@babel/preset-env': 7.28.5(@babel/core@7.29.6)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.6)
@@ -19857,9 +19854,9 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-istanbul@4.1.8(vitest@4.1.8)':
+  '@vitest/coverage-istanbul@4.1.8(supports-color@8.1.1)(vitest@4.1.8)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@istanbuljs/schema': 0.1.3
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -19870,6 +19867,22 @@ snapshots:
       obug: 2.1.1
       tinyrainbow: 3.1.0
       vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(happy-dom@20.10.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@22.19.15)(esbuild@0.28.1)(jiti@2.6.1)(less@4.4.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-istanbul@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@istanbuljs/schema': 0.1.3
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(happy-dom@20.10.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.6.1)(less@4.4.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -20137,7 +20150,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 4.0.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -20418,7 +20431,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  azurite@3.35.0:
+  azurite@3.35.0(supports-color@8.1.1):
     dependencies:
       '@azure/ms-rest-js': 1.11.2
       applicationinsights: 2.9.8
@@ -20434,7 +20447,7 @@ snapshots:
       multistream: 2.1.1
       mysql2: 3.15.3
       rimraf: 3.0.2
-      sequelize: 6.37.8(mysql2@3.15.3)(tedious@16.7.1)
+      sequelize: 6.37.8(mysql2@3.15.3)(supports-color@8.1.1)(tedious@16.7.1)
       stoppable: 1.1.0
       tedious: 16.7.1
       to-readable-stream: 2.1.0
@@ -20459,7 +20472,7 @@ snapshots:
 
   babel-loader@9.2.1(@babel/core@7.29.6)(webpack@5.105.4(esbuild@0.28.1)):
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
       webpack: 5.105.4(esbuild@0.28.1)
@@ -20471,7 +20484,7 @@ snapshots:
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.29.6):
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.6)
       semver: 6.3.1
     transitivePeerDependencies:
@@ -20479,7 +20492,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.6):
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.6)
       core-js-compat: 3.47.0
     transitivePeerDependencies:
@@ -20487,7 +20500,7 @@ snapshots:
 
   babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.29.6):
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
@@ -20548,7 +20561,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -21984,7 +21997,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@4.0.1: {}
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -22086,7 +22099,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -22133,6 +22146,10 @@ snapshots:
   flat@5.0.2: {}
 
   fn.name@1.1.0: {}
+
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@8.1.1)
 
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
@@ -22220,7 +22237,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-own-enumerable-property-symbols@3.0.2: {}
@@ -24210,7 +24227,33 @@ snapshots:
       follow-redirects: 1.16.0(debug@4.4.3)
       https-proxy-agent: 7.0.6
       mongodb: 6.21.0
-      new-find-package-json: 2.0.0
+      new-find-package-json: 2.0.0(supports-color@8.1.1)
+      semver: 7.7.4
+      tar-stream: 3.1.7
+      tslib: 2.8.1
+      yauzl: 3.2.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-abort-controller
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - react-native-b4a
+      - snappy
+      - socks
+      - supports-color
+
+  mongodb-memory-server-core@10.3.0(supports-color@8.1.1):
+    dependencies:
+      async-mutex: 0.5.0
+      camelcase: 6.3.0
+      debug: 4.4.3(supports-color@8.1.1)
+      find-cache-dir: 3.3.2
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      https-proxy-agent: 7.0.6
+      mongodb: 6.21.0
+      new-find-package-json: 2.0.0(supports-color@8.1.1)
       semver: 7.7.4
       tar-stream: 3.1.7
       tslib: 2.8.1
@@ -24243,6 +24286,22 @@ snapshots:
       - socks
       - supports-color
 
+  mongodb-memory-server@10.3.0(supports-color@8.1.1):
+    dependencies:
+      mongodb-memory-server-core: 10.3.0(supports-color@8.1.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-abort-controller
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - react-native-b4a
+      - snappy
+      - socks
+      - supports-color
+
   mongodb@6.18.0:
     dependencies:
       '@mongodb-js/saslprep': 1.3.2
@@ -24255,13 +24314,13 @@ snapshots:
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
 
-  mongoose@8.17.0:
+  mongoose@8.17.0(supports-color@8.1.1):
     dependencies:
       bson: 6.10.4
       kareem: 2.6.3
       mongodb: 6.18.0
       mpath: 0.9.0
-      mquery: 5.0.0
+      mquery: 5.0.0(supports-color@8.1.1)
       ms: 2.1.3
       sift: 17.1.3
     transitivePeerDependencies:
@@ -24286,7 +24345,7 @@ snapshots:
 
   mpath@0.9.0: {}
 
-  mquery@5.0.0:
+  mquery@5.0.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -24341,7 +24400,7 @@ snapshots:
   needle@3.3.1:
     dependencies:
       iconv-lite: 0.6.3
-      sax: 1.4.3
+      sax: 1.5.0
     optional: true
 
   negotiator@0.6.3: {}
@@ -24352,7 +24411,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  new-find-package-json@2.0.0:
+  new-find-package-json@2.0.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -25570,7 +25629,7 @@ snapshots:
 
   react-docgen@8.0.2:
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
@@ -26100,9 +26159,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sax@1.4.3:
-    optional: true
-
   sax@1.5.0: {}
 
   saxes@6.0.0:
@@ -26194,7 +26250,7 @@ snapshots:
 
   sequelize-pool@7.1.0: {}
 
-  sequelize@6.37.8(mysql2@3.15.3)(tedious@16.7.1):
+  sequelize@6.37.8(mysql2@3.15.3)(supports-color@8.1.1)(tedious@16.7.1):
     dependencies:
       '@types/debug': 4.1.12
       '@types/validator': 13.15.10
@@ -27361,7 +27417,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/node': 22.19.15
       '@vitest/browser-playwright': 4.1.8(playwright@1.59.0)(vite@8.0.16(@types/node@22.19.15)(esbuild@0.28.1)(jiti@2.6.1)(less@4.4.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
-      '@vitest/coverage-istanbul': 4.1.8(vitest@4.1.8)
+      '@vitest/coverage-istanbul': 4.1.8(supports-color@8.1.1)(vitest@4.1.8)
       happy-dom: 20.10.1
       jsdom: 26.1.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,7 @@ auditConfig:
     - GHSA-8v8x-cx79-35w7
     - GHSA-wpg9-53fq-2r8h
     - GHSA-q7rr-3cgh-j5r3
-    - GHSA-869p-cjfg-cm3x  # jws@4.0.0: Improperly Verifies HMAC Signature (transitive from azurite)
+    - GHSA-869p-cjfg-cm3x # jws@4.0.0: Improperly Verifies HMAC Signature (transitive from azurite)
 
 allowBuilds:
   '@apollo/protobufjs': true
@@ -113,7 +113,7 @@ overrides:
   postcss: 8.5.10
   protobufjs: 7.6.3
   ip-address: ^10.1.1
-  fast-uri: ^3.1.2
+  fast-uri: ^4.0.1
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@babel/core': ^7.29.6
   'js-yaml@4.1.1': 4.2.0
@@ -145,3 +145,6 @@ packageExtensions:
 
 patchedDependencies:
   '@azure/functions@4.11.0': patches/@azure__functions@4.11.0.patch
+
+minimumReleaseAgeExclude:
+  - fast-uri@3.1.3 || 4.0.1


### PR DESCRIPTION
Introduce support for `oidcConfigName` to filter users based on their OIDC configuration. Update related tests to ensure correct functionality.

## Summary by Sourcery

Add OIDC config–aware user filtering to the mock OAuth2 server and wire portal discovery metadata through so each portal uses the correct scoped user store.

New Features:
- Support associating mock OAuth2 users with an OIDC configuration via the oidcConfigName field.
- Scope file-based mock user stores to a specific OIDC config, while allowing shared users without a config binding.
- Expose the original mock-oidc.json config name on discovered portal configurations and use it when creating user stores.

Enhancements:
- Harden user loading by skipping entries with non-string oidcConfigName and emitting a warning.
- Extend portal discovery tests to validate configName behavior and user store scoping semantics.

Build:
- Update pnpm workspace overrides to fast-uri@4.0.1 and document minimumReleaseAge exclusion for fast-uri.
- Bump pnpm to version 11.9.0 in package metadata and CI/deployment pipelines.

Tests:
- Add comprehensive tests covering oidcConfigName-based filtering across base and overlay user files and lookup methods.
- Add portal discovery tests ensuring configName remains distinct from registration names and is propagated correctly.