### PR TITLE
Refactor build pipeline to enable JRE auto provisioning

### DIFF
--- a/build-pipeline/core/monorepo-build-stage.yml
+++ b/build-pipeline/core/monorepo-build-stage.yml
@@ -355,34 +355,7 @@ stages:
       env:
         SNYK_TOKEN: $(SNYK_TOKEN)
 
-    # Cache Java JRE
-    - task: Cache@2
-      displayName: 'Java: Restore JRE Cache'
-      condition: and(succeeded(), eq(${{parameters.disableSonarCloudTasks}}, False))
-      inputs:
-        key: 'java | "$(Agent.OS)" | openjdk-17-jre-headless'
-        restoreKeys: |
-          java | "$(Agent.OS)"
-        path: '/usr/lib/jvm/java-17-openjdk-amd64'
-        cacheHitVar: JAVA_CACHE_HIT
 
-    # Install Java JRE if cache is missed
-    - task: Bash@3
-      displayName: 'Java: Install JRE if cache missed'
-      condition: and(ne(variables.JAVA_CACHE_HIT, 'true'), eq(${{parameters.disableSonarCloudTasks}}, False))
-      inputs:
-        targetType: 'inline'
-        script: |
-          set -euo pipefail
-          echo "Installing Java 17 JRE..."
-          sudo apt-get update
-          sudo apt-get install -y openjdk-17-jre-headless
-          java -version
-          echo "JAVA_HOME set to: $JAVA_HOME"
-          # Ensure JRE directory is cached
-          sudo chmod -R 755 /usr/lib/jvm/java-17-openjdk-amd64
-      env:
-        JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
 
     # Cache SonarCloud scanner engine
     - task: Cache@2
@@ -412,11 +385,8 @@ stages:
           fi
           echo "SONAR_TOKEN PRESENT: True"
 
-          # Verify Java installation
-          echo "Verifying Java installation..."
-          java -version
-          echo "JAVA_HOME: $JAVA_HOME"
-          echo "SONAR_SCANNER_JAVA_PATH: $SONAR_SCANNER_JAVA_PATH"
+          # SonarScanner (>=4.0) auto-provisions its own JRE; no system java required.
+          echo "SonarScanner will auto-provision its JRE (if needed)."
           echo "SONAR_CACHE_HIT: $SONAR_CACHE_HIT"
 
           # Run SonarCloud analysis
@@ -456,9 +426,6 @@ stages:
         workingDirectory: ''
       env:
         SONAR_USER_HOME: /home/vsts/work/_temp/.sonar
-        JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-        SONAR_SCANNER_JAVA_PATH: /usr/lib/jvm/java-17-openjdk-amd64/bin/java
-        SONAR_SCANNER_SKIP_JRE_PROVISIONING: true
         SONAR_TOKEN: $(SONAR_TOKEN)
 
     # SonarCloud: Break the build if it doesn't pass the Quality Gate

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,9 +129,7 @@ overrides:
   jiti: 2.6.1
   rollup: ^4.59.0
   '@ant-design/pro-layout>path-to-regexp': ^8.4.0
-  brace-expansion@1.1.12: 1.1.13
-  brace-expansion@5.0.4: 5.0.6
-  brace-expansion@5.0.5: 5.0.6
+  brace-expansion: 5.0.7
   diff@4.0.2: 4.0.4
   '@protobufjs/codegen': 2.0.5
   '@protobufjs/utf8': 1.1.1
@@ -152,7 +150,7 @@ overrides:
   node-forge@<1.3.2: '>=1.3.2'
   picomatch: ^4.0.4
   webpack: ^5.105.4
-  webpack-dev-server: ^5.2.5
+  webpack-dev-server: ^5.2.6
   express-rate-limit: 8.5.1
   '@azure/ms-rest-js>uuid': ^3.4.0
   azurite>uuid: ^3.4.0
@@ -7818,14 +7816,11 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
-
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -8257,9 +8252,6 @@ packages:
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concurrently@9.2.1:
     resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
@@ -13749,8 +13741,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.5:
-    resolution: {integrity: sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==}
+  webpack-dev-server@5.2.6:
+    resolution: {integrity: sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -16269,7 +16261,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.105.4(esbuild@0.28.1)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.5(webpack@5.105.4(esbuild@0.28.1))
+      webpack-dev-server: 5.2.6(webpack@5.105.4(esbuild@0.28.1))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@parcel/css'
@@ -20606,16 +20598,11 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.13:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
   brace-expansion@2.0.3:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -21071,8 +21058,6 @@ snapshots:
       - supports-color
 
   compute-scroll-into-view@3.1.1: {}
-
-  concat-map@0.0.1: {}
 
   concurrently@9.2.1:
     dependencies:
@@ -24189,11 +24174,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 5.0.7
 
   minimatch@9.0.9:
     dependencies:
@@ -27517,7 +27502,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.105.4(esbuild@0.28.1)
 
-  webpack-dev-server@5.2.5(webpack@5.105.4(esbuild@0.28.1)):
+  webpack-dev-server@5.2.6(webpack@5.105.4(esbuild@0.28.1)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,9 +80,7 @@ overrides:
   jiti: 2.6.1
   rollup: ^4.59.0
   '@ant-design/pro-layout>path-to-regexp': ^8.4.0
-  'brace-expansion@1.1.12': 1.1.13
-  'brace-expansion@5.0.4': 5.0.6
-  'brace-expansion@5.0.5': 5.0.6
+  brace-expansion: 5.0.7
   'diff@4.0.2': 4.0.4
   '@protobufjs/codegen': 2.0.5
   '@protobufjs/utf8': 1.1.1
@@ -103,7 +101,7 @@ overrides:
   node-forge@<1.3.2: '>=1.3.2'
   picomatch: ^4.0.4
   webpack: ^5.105.4
-  webpack-dev-server: ^5.2.5
+  webpack-dev-server: ^5.2.6
   express-rate-limit: 8.5.1
   '@azure/ms-rest-js>uuid': '^3.4.0'
   'azurite>uuid': '^3.4.0'


### PR DESCRIPTION
Remove Java JRE caching and installation tasks to allow SonarScanner to auto-provision its own JRE, improving build efficiency and reliability. Fix issues related to the Sonar scanner in the process.

## Summary by Sourcery

Refactor the monorepo build stage to rely on SonarScanner's built-in JRE provisioning instead of managing a system JRE in the pipeline.

Enhancements:
- Remove Java JRE caching and conditional installation steps from the build pipeline to simplify SonarCloud setup.
- Update SonarCloud analysis step configuration and logging to reflect automatic JRE provisioning by SonarScanner instead of using system Java.