### PR TITLE
blob_showcase_infra

### DIFF
--- a/apps/ui-staff/src/App.tsx
+++ b/apps/ui-staff/src/App.tsx
@@ -28,7 +28,8 @@ function StaffRoutes() {
 	const canManageFinance = perms?.canManageFinance === true;
 	const canManageTechAdmin = perms?.canManageTechAdmin === true;
 	const canViewDatabaseDocuments = perms?.canViewDatabaseDocuments === true;
-	const canAccessTechAdmin = canManageTechAdmin || canViewDatabaseDocuments;
+	const canViewBlobExplorer = perms?.canViewBlobExplorer === true;
+	const canAccessTechAdmin = canManageTechAdmin || canViewDatabaseDocuments || canViewBlobExplorer;
 	const canViewRoles = perms?.canViewRoles === true;
 	const canAddRole = perms?.canAddRole === true;
 	const canEditRole = perms?.canEditRole === true;

--- a/apps/ui-staff/src/hooks/use-staff-permissions.ts
+++ b/apps/ui-staff/src/hooks/use-staff-permissions.ts
@@ -35,6 +35,7 @@ const CURRENT_STAFF_USER_QUERY = gql`
 					techAdminPermissions {
 						canManageTechAdmin
 						canViewDatabaseDocuments
+						canViewBlobExplorer
 					}
 				}
 			}
@@ -51,6 +52,7 @@ interface StaffPermissions {
 	canManageFinance: boolean;
 	canManageTechAdmin: boolean;
 	canViewDatabaseDocuments: boolean;
+	canViewBlobExplorer: boolean;
 	canViewRoles: boolean;
 	canAddRole: boolean;
 	canEditRole: boolean;
@@ -74,7 +76,7 @@ interface StaffUserQueryResult {
 				userPermissions: { canManageUsers: boolean; canAssignStaffRoles: boolean; canViewStaffUsers: boolean };
 				staffRolePermissions: { canViewRoles: boolean; canAddRole: boolean; canEditRole: boolean; canRemoveRole: boolean };
 				financePermissions: { canManageFinance: boolean };
-				techAdminPermissions: { canManageTechAdmin: boolean; canViewDatabaseDocuments: boolean };
+				techAdminPermissions: { canManageTechAdmin: boolean; canViewDatabaseDocuments: boolean; canViewBlobExplorer: boolean };
 			};
 		};
 	};
@@ -107,6 +109,7 @@ export const useStaffPermissions = (): {
 				canManageFinance: rolePermissions.financePermissions.canManageFinance || isTechAdmin,
 				canManageTechAdmin: isTechAdmin,
 				canViewDatabaseDocuments: rolePermissions.techAdminPermissions.canViewDatabaseDocuments || isTechAdmin,
+				canViewBlobExplorer: rolePermissions.techAdminPermissions.canViewBlobExplorer || isTechAdmin,
 				canViewRoles: rolePermissions.staffRolePermissions.canViewRoles || rolePermissions.communityPermissions.canManageStaffRolesAndPermissions || isTechAdmin,
 				canAddRole: rolePermissions.staffRolePermissions.canAddRole || rolePermissions.communityPermissions.canManageStaffRolesAndPermissions || isTechAdmin,
 				canEditRole: rolePermissions.staffRolePermissions.canEditRole || rolePermissions.communityPermissions.canManageStaffRolesAndPermissions || isTechAdmin,

--- a/build-pipeline/core/monorepo-build-stage.yml
+++ b/build-pipeline/core/monorepo-build-stage.yml
@@ -69,15 +69,11 @@ stages:
         path: '/opt/hostedtoolcache/func'
         cacheHitVar: FUNC_TOOLS_CACHE_HIT
 
-    # Ensure the correct version of function tools are installed.
-    # Temporary change to use npm global install due to github repo being restricted
-    - task: Bash@3
-      displayName: 'Install: func tools - 4.2.1'
+    # Ensure the correct version of Azure Functions Core Tools are installed.
+    # Use the FuncToolsInstaller task instead of npm global install to avoid registry/auth issues.
+    - task: FuncToolsInstaller@0
+      displayName: 'Install: func tools - latest'
       condition: and(ne(variables.FUNC_TOOLS_CACHE_HIT, 'true'), ne(variables.FUNC_TOOLS_CACHE_HIT, 'inexact'))
-      inputs:
-        targetType: 'inline'
-        script: |
-          npm install -g azure-functions-core-tools
         
     # Cache PNPM store to speed up build process.
     - task: Cache@2

--- a/codegen.yml
+++ b/codegen.yml
@@ -169,6 +169,20 @@ generates:
       - typescript-operations
       - typed-document-node
 
+  './packages/ocom/ui-staff-route-tech-admin/src/generated.tsx':
+    documents:
+      - './packages/ocom/ui-staff-route-tech-admin/src/**/**.graphql'
+    config:
+      withHooks: true
+      withHOC: false
+      withComponent: false
+      useTypeImports: true
+      enumsAsTypes: true
+    plugins:
+      - typescript
+      - typescript-operations
+      - typed-document-node
+
   # Cellix core base type defs (static array for rolldown bundling)
   './packages/cellix/graphql-core/src/schema/base-type-defs.generated.ts':
     plugins:

--- a/packages/cellix/serenity-framework/src/servers/process-test-server.test.ts
+++ b/packages/cellix/serenity-framework/src/servers/process-test-server.test.ts
@@ -67,7 +67,7 @@ describe('ProcessTestServer', () => {
 	});
 
 	it('closes configured ports before spawning', async () => {
-		childProcessMock.execFileSync.mockReturnValue('123\n456\n');
+		childProcessMock.execFileSync.mockReturnValueOnce('123\n456\n').mockReturnValueOnce('').mockReturnValueOnce('');
 		const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
 		const server = new ProcessTestServer({
 			serverName: 'fixed-port server',
@@ -89,6 +89,30 @@ describe('ProcessTestServer', () => {
 			});
 			expect(kill).toHaveBeenCalledWith(123, 'SIGTERM');
 			expect(kill).toHaveBeenCalledWith(456, 'SIGTERM');
+			expect(server.isRunning()).toBe(true);
+		} finally {
+			await server.stop();
+			kill.mockRestore();
+		}
+	});
+
+	it('waits for a port to become free before starting a replacement process', async () => {
+		childProcessMock.execFileSync.mockReturnValueOnce('321\n').mockReturnValueOnce('321\n').mockReturnValueOnce('').mockReturnValueOnce('');
+		const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+		const server = new ProcessTestServer({
+			serverName: 'retry-port server',
+			executable: process.execPath,
+			spawnArgs: ['-e', "console.log('READY'); setInterval(() => undefined, 1_000)"],
+			cwd: process.cwd(),
+			readyMarker: 'READY',
+			url: 'process://retry-port',
+			portsToCloseBeforeStart: () => 27_018,
+			shutdownTimeoutMs: 500,
+		});
+
+		try {
+			await server.start();
+			expect(kill).toHaveBeenCalledWith(321, 'SIGTERM');
 			expect(server.isRunning()).toBe(true);
 		} finally {
 			await server.stop();

--- a/packages/cellix/serenity-framework/src/servers/process-test-server.ts
+++ b/packages/cellix/serenity-framework/src/servers/process-test-server.ts
@@ -59,7 +59,7 @@ export class ProcessTestServer implements TestServer {
 			return;
 		}
 
-		this.closePortsBeforeStart();
+		await this.closePortsBeforeStart();
 
 		const executable = this.value(this.options.executable);
 		const spawnArgs = this.value(this.options.spawnArgs);
@@ -270,33 +270,20 @@ export class ProcessTestServer implements TestServer {
 		childProcess.kill(signal);
 	}
 
-	private closePortsBeforeStart(): void {
+	private async closePortsBeforeStart(): Promise<void> {
 		const ports = this.value(this.options.portsToCloseBeforeStart);
 		for (const port of Array.isArray(ports) ? ports : ports === undefined ? [] : [ports]) {
-			this.closeProcessesListeningOnPort(port);
+			await this.closeProcessesListeningOnPort(port);
+			await this.waitForPortToBecomeFree(port, 5_000);
 		}
 	}
 
-	private closeProcessesListeningOnPort(port: number): void {
+	private async closeProcessesListeningOnPort(port: number): Promise<void> {
 		if (process.platform === 'win32') {
 			return;
 		}
 
-		let output = '';
-		try {
-			output = execFileSync('lsof', ['-ti', `tcp:${port}`], {
-				encoding: 'utf-8',
-				stdio: ['ignore', 'pipe', 'ignore'],
-			});
-		} catch {
-			return;
-		}
-
-		const pids = output
-			.split('\n')
-			.map((pid) => Number.parseInt(pid, 10))
-			.filter((pid) => Number.isFinite(pid));
-
+		const pids = this.getPidsListeningOnPort(port);
 		for (const pid of pids) {
 			try {
 				process.kill(pid, 'SIGTERM');
@@ -304,6 +291,51 @@ export class ProcessTestServer implements TestServer {
 				/* Process already exited. */
 			}
 		}
+
+		await this.waitForPortToBecomeFree(port, 250);
+		const remainingPids = this.getPidsListeningOnPort(port);
+		for (const pid of remainingPids) {
+			try {
+				process.kill(pid, 'SIGKILL');
+			} catch {
+				/* Process already exited. */
+			}
+		}
+	}
+
+	private async waitForPortToBecomeFree(port: number, timeoutMs: number): Promise<void> {
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			if (this.getPidsListeningOnPort(port).length === 0) {
+				return;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+	}
+
+	private getPidsListeningOnPort(port: number): number[] {
+		if (process.platform === 'win32') {
+			return [];
+		}
+
+		let output: string;
+		try {
+			output = execFileSync('lsof', ['-ti', `tcp:${port}`], {
+				encoding: 'utf-8',
+				stdio: ['ignore', 'pipe', 'ignore'],
+			});
+		} catch {
+			return [];
+		}
+
+		if (typeof output !== 'string') {
+			return [];
+		}
+
+		return output
+			.split('\n')
+			.map((pid: string) => Number.parseInt(pid, 10))
+			.filter((pid: number) => Number.isFinite(pid));
 	}
 
 	private value<T>(value: T | (() => T) | undefined): T | undefined {

--- a/packages/cellix/service-blob-storage/README.md
+++ b/packages/cellix/service-blob-storage/README.md
@@ -21,7 +21,7 @@ Choose `ServiceClientBlobStorage` when the same application also needs to sign d
 - requires `accountName`
 - optionally accepts a `TokenCredential`
 - does not accept any connection string configuration
-- provides `uploadText()`, `listBlobs()`, and `deleteBlob()`
+- provides `uploadText()`, `listBlobs()`, `deleteBlob()`, `listContainers()`, `listBlobHierarchy()`, and `downloadBlob()`
 
 `ServiceClientBlobStorage` extends `ServiceBlobStorage`:
 

--- a/packages/cellix/service-blob-storage/manifest.md
+++ b/packages/cellix/service-blob-storage/manifest.md
@@ -8,6 +8,7 @@
 
 - Managed-identity startup and shutdown for server-side Azure Blob access
 - General blob operations that are stable and reusable across applications
+- Hierarchical container exploration with continuation-token pagination, metadata/tags, and bounded blob download
 - Shared-key read SAS token creation and blob-scoped authorization header creation through a dedicated client-signing service
 - Container/blob addressing and request typing that stays framework-level rather than app-specific
 
@@ -32,7 +33,7 @@
 - `ServiceBlobStorage` is managed-identity-only for server-side blob operations
 - `ServiceClientBlobStorage` extends `ServiceBlobStorage` and adds SharedKey signing through `signingConnectionString`
 - `ServiceClientBlobStorage` may also use that required signing connection string to target local emulator endpoints such as Azurite
-- Consumers interact with framework-defined operations such as text upload, blob deletion, blob listing, read SAS token creation, and authorization-header creation
+- Consumers interact with framework-defined operations such as text upload, blob deletion, blob listing, hierarchical explorer listing with pagination, blob download, read SAS token creation, and authorization-header creation
 - Application packages should expose narrower scoped interfaces before surfacing either service through `ApiContext`
 
 ## Package boundaries

--- a/packages/cellix/service-blob-storage/src/index.ts
+++ b/packages/cellix/service-blob-storage/src/index.ts
@@ -1,21 +1,29 @@
 export type { BlobUploadCommonResponse } from '@azure/storage-blob';
 export type {
 	BlobAddress,
+	BlobContainerItem,
+	BlobDownloadResult,
+	BlobExplorerItem,
+	BlobFolderItem,
+	BlobHierarchyPage,
 	BlobListItem,
 	BlobStorage,
 	BlobUploadAuthorizationHeader,
 	ClientBlobStorage,
 	CreateBlobAuthorizationHeaderRequest,
 	CreateBlobSasUrlRequest,
+	ListBlobHierarchyRequest,
 	ListBlobsRequest,
 	ServiceBlobStorageOptions,
 	ServiceClientBlobStorageOptions,
 	UploadTextBlobRequest,
 } from './interfaces.ts';
+export { BLOB_DOWNLOAD_MAX_BYTES } from './interfaces.ts';
 /**
  * Managed-identity-backed framework blob-storage service for server-side blob operations.
  *
- * @returns A started service instance that exposes upload, list, and delete operations after `startUp()`.
+ * @returns A started service instance that exposes upload, list, delete, hierarchical
+ * explorer listing, and download operations after `startUp()`.
  *
  * @example
  * ```ts

--- a/packages/cellix/service-blob-storage/src/interfaces.ts
+++ b/packages/cellix/service-blob-storage/src/interfaces.ts
@@ -113,6 +113,137 @@ export interface BlobListItem {
 }
 
 /**
+ * Public summary for a blob container in the storage account.
+ *
+ * @property name - Container name.
+ */
+export interface BlobContainerItem {
+	name: string;
+}
+
+/**
+ * Virtual folder entry discovered while listing a hierarchical blob path.
+ *
+ * Azure Blob Storage has no real folders; hierarchy is derived from `/`
+ * segments in blob names. `prefix` is the full path prefix that should be used
+ * for the next listing request when the user navigates into the folder.
+ *
+ * @property name - Immediate folder segment (no trailing slash).
+ * @property prefix - Full virtual-folder prefix ending with `/`.
+ */
+export interface BlobFolderItem {
+	name: string;
+	prefix: string;
+}
+
+/**
+ * Rich blob summary used by storage explorers.
+ *
+ * Unlike {@link BlobListItem}, this includes content-type, size, timestamps,
+ * metadata, and index tags so UI tooling can render listings without issuing a
+ * second properties request for every row.
+ *
+ * @property name - Immediate blob name segment relative to the current prefix.
+ * @property blobName - Full blob path relative to the container root.
+ * @property url - Absolute blob URL.
+ * @property contentType - MIME type when known.
+ * @property contentLength - Blob size in bytes.
+ * @property lastModified - Last-modified timestamp when known.
+ * @property metadata - Blob metadata key/value pairs.
+ * @property tags - Blob index tags.
+ */
+export interface BlobExplorerItem {
+	name: string;
+	blobName: string;
+	url: string;
+	contentType?: string;
+	contentLength: number;
+	lastModified?: Date;
+	metadata: Record<string, string>;
+	tags: Record<string, string>;
+}
+
+/**
+ * Request contract for hierarchical, paginated blob exploration.
+ *
+ * Prefer this over {@link ListBlobsRequest} when building explorer UIs that
+ * must scale to large containers. The service lists only the selected
+ * `prefix` segment (one hierarchy level) and returns an opaque continuation
+ * token for the next page.
+ *
+ * Optional filters:
+ * - `nameContains` filters blob/folder names after Azure returns the page
+ * - `metadataKey`/`metadataValue` require matching metadata on blobs
+ * - `tagKey`/`tagValue` use Azure blob-index tag queries when both are set
+ *
+ * @property containerName - Container to explore.
+ * @property prefix - Virtual folder prefix; omit or `''` for the container root.
+ * @property pageSize - Maximum entries (folders + blobs) per page (1–100).
+ * @property continuationToken - Opaque token from a previous page response.
+ * @property nameContains - Case-insensitive substring filter for names.
+ * @property metadataKey - Metadata key that must be present on listed blobs.
+ * @property metadataValue - Optional exact metadata value to match.
+ * @property tagKey - Blob index tag key to filter by.
+ * @property tagValue - Blob index tag value to filter by.
+ */
+export interface ListBlobHierarchyRequest {
+	containerName: string;
+	prefix?: string;
+	pageSize?: number;
+	continuationToken?: string;
+	nameContains?: string;
+	metadataKey?: string;
+	metadataValue?: string;
+	tagKey?: string;
+	tagValue?: string;
+}
+
+/**
+ * One page of hierarchical blob explorer results.
+ *
+ * @property folders - Immediate virtual folders under the current prefix.
+ * @property blobs - Blobs at the current hierarchy level.
+ * @property continuationToken - Token for the next page, or `undefined` when complete.
+ */
+export interface BlobHierarchyPage {
+	folders: BlobFolderItem[];
+	blobs: BlobExplorerItem[];
+	continuationToken?: string;
+}
+
+/**
+ * Downloaded blob payload for preview/download tooling.
+ *
+ * Content is capped by the service so explorers cannot load unbounded blobs
+ * into memory. Callers should treat oversized responses as errors and fall
+ * back to a signed URL when available.
+ *
+ * @property contentType - MIME type when known.
+ * @property contentLength - Full blob size in bytes.
+ * @property lastModified - Last-modified timestamp when known.
+ * @property metadata - Blob metadata.
+ * @property tags - Blob index tags.
+ * @property content - Raw bytes (may be truncated only when the service errors instead).
+ * @property encoding - Hint for consumers: `utf-8` when the bytes are text-compatible.
+ */
+export interface BlobDownloadResult {
+	contentType?: string;
+	contentLength: number;
+	lastModified?: Date;
+	metadata: Record<string, string>;
+	tags: Record<string, string>;
+	content: Uint8Array;
+	encoding?: 'utf-8' | 'binary';
+	url: string;
+}
+
+/**
+ * Maximum number of bytes `downloadBlob` will buffer in memory.
+ * Larger blobs should be accessed via signed URLs instead.
+ */
+export const BLOB_DOWNLOAD_MAX_BYTES = 5 * 1024 * 1024;
+
+/**
  * Request contract for generating a blob-scoped read SAS token.
  *
  * Use this with `ClientBlobStorage.generateReadSasToken()` when a server needs
@@ -270,6 +401,39 @@ export interface BlobStorage {
 	 * @returns A promise that resolves to a flat list of matching blobs.
 	 */
 	listBlobs(request: ListBlobsRequest): Promise<BlobListItem[]>;
+
+	/**
+	 * Lists all blob containers in the configured storage account.
+	 *
+	 * @returns A promise that resolves to container names sorted alphabetically.
+	 */
+	listContainers(): Promise<BlobContainerItem[]>;
+
+	/**
+	 * Lists one hierarchy level of blobs and virtual folders with pagination.
+	 *
+	 * Only the selected `prefix` path is queried. Descendant folders are not
+	 * recursively enumerated. When both `tagKey` and `tagValue` are provided,
+	 * Azure blob-index tag filtering is used; other filters are applied to the
+	 * returned page.
+	 *
+	 * @param request - Container, optional virtual-folder prefix, page size,
+	 * continuation token, and optional name/metadata/tag filters.
+	 * @returns A promise that resolves to folders, blobs, and an optional
+	 * continuation token for the next page.
+	 */
+	listBlobHierarchy(request: ListBlobHierarchyRequest): Promise<BlobHierarchyPage>;
+
+	/**
+	 * Downloads a blob into memory for preview or small-file download tooling.
+	 *
+	 * Rejects when the blob exceeds {@link BLOB_DOWNLOAD_MAX_BYTES}. Callers
+	 * that need large files should generate a short-lived SAS URL instead.
+	 *
+	 * @param address - Container and blob name identifying the blob to download.
+	 * @returns A promise that resolves to content bytes plus properties, metadata, and tags.
+	 */
+	downloadBlob(address: BlobAddress): Promise<BlobDownloadResult>;
 }
 
 /**

--- a/packages/cellix/service-blob-storage/src/service-blob-storage.ts
+++ b/packages/cellix/service-blob-storage/src/service-blob-storage.ts
@@ -1,12 +1,98 @@
 import { DefaultAzureCredential, type TokenCredential } from '@azure/identity';
 import { BlobServiceClient, type BlobUploadCommonResponse } from '@azure/storage-blob';
 import type { ServiceBase } from '@cellix/api-services-spec';
-import type { BlobAddress, BlobListItem, BlobStorage, ListBlobsRequest, ServiceBlobStorageOptions, UploadTextBlobRequest } from './interfaces.ts';
+import {
+	BLOB_DOWNLOAD_MAX_BYTES,
+	type BlobAddress,
+	type BlobContainerItem,
+	type BlobDownloadResult,
+	type BlobExplorerItem,
+	type BlobFolderItem,
+	type BlobHierarchyPage,
+	type BlobListItem,
+	type BlobStorage,
+	type ListBlobHierarchyRequest,
+	type ListBlobsRequest,
+	type ServiceBlobStorageOptions,
+	type UploadTextBlobRequest,
+} from './interfaces.ts';
 
 function validateOptions(options: ServiceBlobStorageOptions): void {
 	if (!options.accountName?.trim()) {
 		throw new Error("Provide an 'accountName' for blob client authentication");
 	}
+}
+
+function normalizePrefix(prefix: string | undefined): string {
+	if (!prefix) {
+		return '';
+	}
+	return prefix.endsWith('/') ? prefix : `${prefix}/`;
+}
+
+function immediateName(fullPath: string, prefix: string): string {
+	const relative = fullPath.startsWith(prefix) ? fullPath.slice(prefix.length) : fullPath;
+	const slash = relative.indexOf('/');
+	return slash === -1 ? relative : relative.slice(0, slash);
+}
+
+function isTextCompatible(contentType: string | undefined): boolean {
+	if (!contentType) {
+		return false;
+	}
+	const normalized = contentType.toLowerCase().split(';')[0]?.trim() ?? '';
+	return (
+		normalized.startsWith('text/') ||
+		normalized === 'application/json' ||
+		normalized === 'application/xml' ||
+		normalized === 'application/javascript' ||
+		normalized === 'application/x-javascript' ||
+		normalized.endsWith('+json') ||
+		normalized.endsWith('+xml')
+	);
+}
+
+async function streamToUint8Array(stream: NodeJS.ReadableStream | undefined, maxBytes: number): Promise<Uint8Array> {
+	if (!stream) {
+		return new Uint8Array();
+	}
+	const chunks: Buffer[] = [];
+	let total = 0;
+	for await (const chunk of stream) {
+		const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+		total += buffer.length;
+		if (total > maxBytes) {
+			throw new Error(`Blob exceeds maximum download size of ${maxBytes} bytes`);
+		}
+		chunks.push(buffer);
+	}
+	return new Uint8Array(Buffer.concat(chunks));
+}
+
+function matchesNameFilter(name: string, nameContains: string | undefined): boolean {
+	if (!nameContains?.trim()) {
+		return true;
+	}
+	return name.toLowerCase().includes(nameContains.trim().toLowerCase());
+}
+
+function matchesMetadataFilter(metadata: Record<string, string>, metadataKey: string | undefined, metadataValue: string | undefined): boolean {
+	if (!metadataKey?.trim()) {
+		return true;
+	}
+	const key = metadataKey.trim();
+	const value = metadata[key];
+	if (value === undefined) {
+		return false;
+	}
+	if (metadataValue === undefined || metadataValue === '') {
+		return true;
+	}
+	return value === metadataValue;
+}
+
+function escapeTagValue(value: string): string {
+	return value.replaceAll("'", "''");
 }
 
 export class ServiceBlobStorage implements ServiceBase<BlobStorage>, BlobStorage {
@@ -70,6 +156,51 @@ export class ServiceBlobStorage implements ServiceBase<BlobStorage>, BlobStorage
 		return blobs;
 	}
 
+	public async listContainers(): Promise<BlobContainerItem[]> {
+		const client = this.requireBlobServiceClient();
+		const containers: BlobContainerItem[] = [];
+		for await (const container of client.listContainers()) {
+			containers.push({ name: container.name });
+		}
+		return containers.toSorted((a, b) => a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }));
+	}
+
+	public async listBlobHierarchy(request: ListBlobHierarchyRequest): Promise<BlobHierarchyPage> {
+		const pageSize = Math.min(Math.max(request.pageSize ?? 50, 1), 100);
+		const prefix = normalizePrefix(request.prefix);
+		const hasTagFilter = Boolean(request.tagKey?.trim() && request.tagValue !== undefined && request.tagValue !== '');
+
+		if (hasTagFilter) {
+			return await this.listBlobHierarchyByTags(request, prefix, pageSize);
+		}
+
+		return await this.listBlobHierarchyPage(request, prefix, pageSize);
+	}
+
+	public async downloadBlob(address: BlobAddress): Promise<BlobDownloadResult> {
+		const blobClient = this.getContainerClient(address.containerName).getBlobClient(address.blobName);
+		const properties = await blobClient.getProperties();
+		const contentLength = properties.contentLength ?? 0;
+		if (contentLength > BLOB_DOWNLOAD_MAX_BYTES) {
+			throw new Error(`Blob exceeds maximum download size of ${BLOB_DOWNLOAD_MAX_BYTES} bytes`);
+		}
+
+		const [download, tagsResponse] = await Promise.all([blobClient.download(0, BLOB_DOWNLOAD_MAX_BYTES + 1), blobClient.getTags()]);
+		const content = await streamToUint8Array(download.readableStreamBody, BLOB_DOWNLOAD_MAX_BYTES);
+		const contentType = properties.contentType ?? download.contentType;
+		const lastModified = properties.lastModified ?? download.lastModified;
+		return {
+			...(contentType !== undefined ? { contentType } : {}),
+			contentLength,
+			...(lastModified !== undefined ? { lastModified } : {}),
+			metadata: properties.metadata ?? {},
+			tags: tagsResponse.tags ?? {},
+			content,
+			encoding: isTextCompatible(contentType) ? 'utf-8' : 'binary',
+			url: blobClient.url,
+		};
+	}
+
 	protected setBlobServiceClient(client: BlobServiceClient): void {
 		this.blobServiceClientInternal = client;
 	}
@@ -80,6 +211,153 @@ export class ServiceBlobStorage implements ServiceBase<BlobStorage>, BlobStorage
 
 	protected getBlobServiceUrl(): string {
 		return this.requireBlobServiceClient().url;
+	}
+
+	private async listBlobHierarchyPage(request: ListBlobHierarchyRequest, prefix: string, pageSize: number): Promise<BlobHierarchyPage> {
+		const containerClient = this.getContainerClient(request.containerName);
+		const listOptions = {
+			includeMetadata: true as const,
+			includeTags: true as const,
+			...(prefix ? { prefix } : {}),
+		};
+		const pageSettings = {
+			maxPageSize: pageSize,
+			...(request.continuationToken ? { continuationToken: request.continuationToken } : {}),
+		};
+		const iterator = containerClient.listBlobsByHierarchy('/', listOptions).byPage(pageSettings);
+
+		const page = await iterator.next();
+		if (page.done || !page.value) {
+			return { folders: [], blobs: [] };
+		}
+
+		const folders: BlobFolderItem[] = [];
+		const blobs: BlobExplorerItem[] = [];
+
+		for (const item of page.value.segment.blobItems ?? []) {
+			const name = immediateName(item.name, prefix);
+			if (!matchesNameFilter(name, request.nameContains)) {
+				continue;
+			}
+			const metadata = item.metadata ?? {};
+			if (!matchesMetadataFilter(metadata, request.metadataKey, request.metadataValue)) {
+				continue;
+			}
+			blobs.push({
+				name,
+				blobName: item.name,
+				url: containerClient.getBlockBlobClient(item.name).url,
+				...(item.properties.contentType !== undefined ? { contentType: item.properties.contentType } : {}),
+				contentLength: item.properties.contentLength ?? 0,
+				...(item.properties.lastModified !== undefined ? { lastModified: item.properties.lastModified } : {}),
+				metadata,
+				tags: item.tags ?? {},
+			});
+		}
+
+		for (const blobPrefix of page.value.segment.blobPrefixes ?? []) {
+			const folderPrefix = blobPrefix.name;
+			const name = immediateName(folderPrefix.replace(/\/$/, ''), prefix) || immediateName(folderPrefix, prefix);
+			if (!matchesNameFilter(name, request.nameContains)) {
+				continue;
+			}
+			// Metadata/tag filters apply to blobs only; folders still appear so users can navigate.
+			if (request.metadataKey?.trim()) {
+				continue;
+			}
+			folders.push({
+				name,
+				prefix: folderPrefix.endsWith('/') ? folderPrefix : `${folderPrefix}/`,
+			});
+		}
+
+		const continuationToken = page.value.continuationToken || undefined;
+		return {
+			folders,
+			blobs,
+			...(continuationToken !== undefined ? { continuationToken } : {}),
+		};
+	}
+
+	private async listBlobHierarchyByTags(request: ListBlobHierarchyRequest, prefix: string, pageSize: number): Promise<BlobHierarchyPage> {
+		const tagKey = request.tagKey?.trim() ?? '';
+		const tagValue = request.tagValue ?? '';
+		const query = `@container='${escapeTagValue(request.containerName)}' AND "${escapeTagValue(tagKey)}"='${escapeTagValue(tagValue)}'`;
+		const client = this.requireBlobServiceClient();
+		const containerClient = this.getContainerClient(request.containerName);
+
+		const matchingBlobNames: string[] = [];
+		const folderMap = new Map<string, BlobFolderItem>();
+
+		for await (const item of client.findBlobsByTags(query)) {
+			if (!item.name.startsWith(prefix)) {
+				continue;
+			}
+			const remainder = item.name.slice(prefix.length);
+			if (!remainder) {
+				continue;
+			}
+			const slash = remainder.indexOf('/');
+			if (slash === -1) {
+				matchingBlobNames.push(item.name);
+				continue;
+			}
+			const folderName = remainder.slice(0, slash);
+			if (!matchesNameFilter(folderName, request.nameContains)) {
+				continue;
+			}
+			if (request.metadataKey?.trim()) {
+				continue;
+			}
+			const folderPrefix = `${prefix}${folderName}/`;
+			folderMap.set(folderPrefix, { name: folderName, prefix: folderPrefix });
+		}
+
+		const offset = request.continuationToken ? Number.parseInt(request.continuationToken, 10) : 0;
+		const safeOffset = Number.isFinite(offset) && offset > 0 ? offset : 0;
+
+		const folderEntries = [...folderMap.values()].toSorted((a, b) => a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }));
+		const blobNames = matchingBlobNames.filter((blobName) => matchesNameFilter(immediateName(blobName, prefix), request.nameContains)).toSorted((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }));
+
+		const combined: Array<{ kind: 'folder'; folder: BlobFolderItem } | { kind: 'blob'; blobName: string }> = [
+			...folderEntries.map((folder) => ({ kind: 'folder' as const, folder })),
+			...blobNames.map((blobName) => ({ kind: 'blob' as const, blobName })),
+		];
+
+		const pageItems = combined.slice(safeOffset, safeOffset + pageSize);
+		const folders: BlobFolderItem[] = [];
+		const blobs: BlobExplorerItem[] = [];
+
+		for (const entry of pageItems) {
+			if (entry.kind === 'folder') {
+				folders.push(entry.folder);
+				continue;
+			}
+			const blobClient = containerClient.getBlobClient(entry.blobName);
+			const [properties, tagsResponse] = await Promise.all([blobClient.getProperties(), blobClient.getTags()]);
+			const metadata = properties.metadata ?? {};
+			if (!matchesMetadataFilter(metadata, request.metadataKey, request.metadataValue)) {
+				continue;
+			}
+			blobs.push({
+				name: immediateName(entry.blobName, prefix),
+				blobName: entry.blobName,
+				url: containerClient.getBlockBlobClient(entry.blobName).url,
+				...(properties.contentType !== undefined ? { contentType: properties.contentType } : {}),
+				contentLength: properties.contentLength ?? 0,
+				...(properties.lastModified !== undefined ? { lastModified: properties.lastModified } : {}),
+				metadata,
+				tags: tagsResponse.tags ?? {},
+			});
+		}
+
+		const nextOffset = safeOffset + pageSize;
+		const continuationToken = nextOffset < combined.length ? String(nextOffset) : undefined;
+		return {
+			folders,
+			blobs,
+			...(continuationToken !== undefined ? { continuationToken } : {}),
+		};
 	}
 
 	private requireBlobServiceClient(): BlobServiceClient {

--- a/packages/cellix/service-blob-storage/src/service-blob-storage.ts
+++ b/packages/cellix/service-blob-storage/src/service-blob-storage.ts
@@ -80,15 +80,30 @@ function matchesMetadataFilter(metadata: Record<string, string>, metadataKey: st
 	if (!metadataKey?.trim()) {
 		return true;
 	}
-	const key = metadataKey.trim();
-	const value = metadata[key];
-	if (value === undefined) {
+	const key = metadataKey.trim().toLowerCase();
+	const matchedEntry = Object.entries(metadata).find(([metadataName]) => metadataName.toLowerCase() === key);
+	if (!matchedEntry) {
 		return false;
 	}
 	if (metadataValue === undefined || metadataValue === '') {
 		return true;
 	}
-	return value === metadataValue;
+	return matchedEntry[1].toLowerCase() === metadataValue.trim().toLowerCase();
+}
+
+function matchesTagFilter(tags: Record<string, string>, tagKey: string | undefined, tagValue: string | undefined): boolean {
+	if (!tagKey?.trim()) {
+		return true;
+	}
+	const key = tagKey.trim().toLowerCase();
+	const matchedEntry = Object.entries(tags).find(([tagName]) => tagName.toLowerCase() === key);
+	if (!matchedEntry) {
+		return false;
+	}
+	if (tagValue === undefined || tagValue === '') {
+		return true;
+	}
+	return matchedEntry[1].toLowerCase() === tagValue.trim().toLowerCase();
 }
 
 function escapeTagValue(value: string): string {
@@ -168,9 +183,9 @@ export class ServiceBlobStorage implements ServiceBase<BlobStorage>, BlobStorage
 	public async listBlobHierarchy(request: ListBlobHierarchyRequest): Promise<BlobHierarchyPage> {
 		const pageSize = Math.min(Math.max(request.pageSize ?? 50, 1), 100);
 		const prefix = normalizePrefix(request.prefix);
-		const hasTagFilter = Boolean(request.tagKey?.trim() && request.tagValue !== undefined && request.tagValue !== '');
+		const hasExactTagFilter = Boolean(request.tagKey?.trim() && request.tagValue !== undefined && request.tagValue !== '');
 
-		if (hasTagFilter) {
+		if (hasExactTagFilter) {
 			return await this.listBlobHierarchyByTags(request, prefix, pageSize);
 		}
 
@@ -243,6 +258,9 @@ export class ServiceBlobStorage implements ServiceBase<BlobStorage>, BlobStorage
 			if (!matchesMetadataFilter(metadata, request.metadataKey, request.metadataValue)) {
 				continue;
 			}
+			if (!matchesTagFilter(item.tags ?? {}, request.tagKey, request.tagValue)) {
+				continue;
+			}
 			blobs.push({
 				name,
 				blobName: item.name,
@@ -261,8 +279,7 @@ export class ServiceBlobStorage implements ServiceBase<BlobStorage>, BlobStorage
 			if (!matchesNameFilter(name, request.nameContains)) {
 				continue;
 			}
-			// Metadata/tag filters apply to blobs only; folders still appear so users can navigate.
-			if (request.metadataKey?.trim()) {
+			if (request.metadataKey?.trim() || request.tagKey?.trim()) {
 				continue;
 			}
 			folders.push({

--- a/packages/cellix/service-blob-storage/tests/index.test.ts
+++ b/packages/cellix/service-blob-storage/tests/index.test.ts
@@ -2,30 +2,49 @@ import { createHash } from 'node:crypto';
 import { ServiceBlobStorage, ServiceClientBlobStorage } from '@cellix/service-blob-storage';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { uploadMock, deleteBlobMock, listBlobsFlatMock, blobServiceFromConnectionStringMock, blobServiceConstructorMock, generateBlobSasQueryParametersMock, defaultAzureCredentialMock, MockStorageSharedKeyCredential } = vi.hoisted(
-	() => {
-		class HoistedStorageSharedKeyCredential {
-			public readonly accountName: string;
-			public readonly accountKey: string;
+const {
+	uploadMock,
+	deleteBlobMock,
+	listBlobsFlatMock,
+	listContainersMock,
+	listBlobsByHierarchyMock,
+	findBlobsByTagsMock,
+	getPropertiesMock,
+	getTagsMock,
+	downloadMock,
+	blobServiceFromConnectionStringMock,
+	blobServiceConstructorMock,
+	generateBlobSasQueryParametersMock,
+	defaultAzureCredentialMock,
+	MockStorageSharedKeyCredential,
+} = vi.hoisted(() => {
+	class HoistedStorageSharedKeyCredential {
+		public readonly accountName: string;
+		public readonly accountKey: string;
 
-			constructor(accountName: string, accountKey: string) {
-				this.accountName = accountName;
-				this.accountKey = accountKey;
-			}
+		constructor(accountName: string, accountKey: string) {
+			this.accountName = accountName;
+			this.accountKey = accountKey;
 		}
+	}
 
-		return {
-			uploadMock: vi.fn(),
-			deleteBlobMock: vi.fn(),
-			listBlobsFlatMock: vi.fn(),
-			blobServiceFromConnectionStringMock: vi.fn(),
-			blobServiceConstructorMock: vi.fn(),
-			generateBlobSasQueryParametersMock: vi.fn(),
-			defaultAzureCredentialMock: vi.fn(),
-			MockStorageSharedKeyCredential: HoistedStorageSharedKeyCredential,
-		};
-	},
-);
+	return {
+		uploadMock: vi.fn(),
+		deleteBlobMock: vi.fn(),
+		listBlobsFlatMock: vi.fn(),
+		listContainersMock: vi.fn(),
+		listBlobsByHierarchyMock: vi.fn(),
+		findBlobsByTagsMock: vi.fn(),
+		getPropertiesMock: vi.fn(),
+		getTagsMock: vi.fn(),
+		downloadMock: vi.fn(),
+		blobServiceFromConnectionStringMock: vi.fn(),
+		blobServiceConstructorMock: vi.fn(),
+		generateBlobSasQueryParametersMock: vi.fn(),
+		defaultAzureCredentialMock: vi.fn(),
+		MockStorageSharedKeyCredential: HoistedStorageSharedKeyCredential,
+	};
+});
 
 vi.mock('@azure/identity', () => ({
 	DefaultAzureCredential: class MockDefaultAzureCredential {
@@ -74,11 +93,25 @@ describe('@cellix/service-blob-storage public contract', () => {
 		url: 'https://blob.example.test/container/blob.txt',
 		upload: uploadMock,
 	};
+	const blobClient = {
+		url: 'https://blob.example.test/container/blob.txt',
+		getProperties: getPropertiesMock,
+		getTags: getTagsMock,
+		download: downloadMock,
+	};
 	const containerClient = {
 		url: 'https://blob.example.test/container',
 		getBlockBlobClient: vi.fn(() => blockBlobClient),
+		getBlobClient: vi.fn(() => blobClient),
 		deleteBlob: deleteBlobMock,
 		listBlobsFlat: listBlobsFlatMock,
+		listBlobsByHierarchy: listBlobsByHierarchyMock,
+	};
+	const blobServiceClient = {
+		url: 'https://test-account.blob.core.windows.net',
+		getContainerClient: vi.fn(() => containerClient),
+		listContainers: listContainersMock,
+		findBlobsByTags: findBlobsByTagsMock,
 	};
 
 	beforeEach(() => {
@@ -88,8 +121,8 @@ describe('@cellix/service-blob-storage public contract', () => {
 			getContainerClient: vi.fn(() => containerClient),
 		});
 		blobServiceConstructorMock.mockImplementation((url: string) => ({
+			...blobServiceClient,
 			url,
-			getContainerClient: vi.fn(() => containerClient),
 		}));
 		generateBlobSasQueryParametersMock.mockReturnValue({
 			toString: () => 'sig=token-123&se=2026-05-14T12%3A00%3A00Z&sr=b&sp=r',
@@ -101,6 +134,63 @@ describe('@cellix/service-blob-storage public contract', () => {
 				yield { name: 'b.txt' };
 			})(),
 		);
+		listContainersMock.mockReturnValue(
+			(async function* (): AsyncGenerator<{ name: string }> {
+				await Promise.resolve();
+				yield { name: 'private' };
+				yield { name: 'member-assets' };
+			})(),
+		);
+		listBlobsByHierarchyMock.mockReturnValue({
+			byPage: vi.fn(() => ({
+				next: vi.fn(async () => {
+					await Promise.resolve();
+					return {
+						done: false,
+						value: {
+							continuationToken: 'next-page',
+							segment: {
+								blobPrefixes: [{ name: 'avatars/' }],
+								blobItems: [
+									{
+										name: 'readme.txt',
+										properties: {
+											contentType: 'text/plain',
+											contentLength: 12,
+											lastModified: new Date('2026-05-14T12:00:00.000Z'),
+										},
+										metadata: { source: 'test' },
+										tags: { env: 'dev' },
+									},
+								],
+							},
+						},
+					};
+				}),
+			})),
+		});
+		findBlobsByTagsMock.mockReturnValue(
+			(async function* (): AsyncGenerator<{ name: string }> {
+				await Promise.resolve();
+				yield { name: 'avatars/member-1.png' };
+				yield { name: 'readme.txt' };
+			})(),
+		);
+		getPropertiesMock.mockResolvedValue({
+			contentType: 'text/plain',
+			contentLength: 5,
+			lastModified: new Date('2026-05-14T12:00:00.000Z'),
+			metadata: { source: 'test' },
+		});
+		getTagsMock.mockResolvedValue({ tags: { env: 'dev' } });
+		downloadMock.mockResolvedValue({
+			contentType: 'text/plain',
+			lastModified: new Date('2026-05-14T12:00:00.000Z'),
+			readableStreamBody: (async function* (): AsyncGenerator<Buffer> {
+				await Promise.resolve();
+				yield Buffer.from('hello');
+			})(),
+		});
 	});
 
 	describe('ServiceBlobStorage', () => {
@@ -167,6 +257,105 @@ describe('@cellix/service-blob-storage public contract', () => {
 			});
 
 			expect(deleteBlobMock).toHaveBeenCalledWith('avatars/member-1.json');
+		});
+
+		it('lists containers sorted alphabetically', async () => {
+			const service = new ServiceBlobStorage({ accountName });
+			await service.startUp();
+
+			const result = await service.listContainers();
+
+			expect(listContainersMock).toHaveBeenCalled();
+			expect(result).toEqual([{ name: 'member-assets' }, { name: 'private' }]);
+		});
+
+		it('lists one hierarchy level with folders, blob properties, and a continuation token', async () => {
+			const service = new ServiceBlobStorage({ accountName });
+			await service.startUp();
+
+			const result = await service.listBlobHierarchy({
+				containerName: 'member-assets',
+				prefix: '',
+				pageSize: 20,
+			});
+
+			expect(listBlobsByHierarchyMock).toHaveBeenCalledWith('/', {
+				prefix: undefined,
+				includeMetadata: true,
+				includeTags: true,
+			});
+			expect(result.continuationToken).toBe('next-page');
+			expect(result.folders).toEqual([{ name: 'avatars', prefix: 'avatars/' }]);
+			expect(result.blobs).toEqual([
+				{
+					name: 'readme.txt',
+					blobName: 'readme.txt',
+					url: 'https://blob.example.test/container/blob.txt',
+					contentType: 'text/plain',
+					contentLength: 12,
+					lastModified: new Date('2026-05-14T12:00:00.000Z'),
+					metadata: { source: 'test' },
+					tags: { env: 'dev' },
+				},
+			]);
+		});
+
+		it('filters hierarchy results with blob index tags', async () => {
+			const service = new ServiceBlobStorage({ accountName });
+			await service.startUp();
+
+			const result = await service.listBlobHierarchy({
+				containerName: 'member-assets',
+				prefix: '',
+				tagKey: 'env',
+				tagValue: 'dev',
+				pageSize: 10,
+			});
+
+			expect(findBlobsByTagsMock).toHaveBeenCalledWith(`@container='member-assets' AND "env"='dev'`);
+			expect(result.folders).toEqual([{ name: 'avatars', prefix: 'avatars/' }]);
+			expect(result.blobs.map((blob) => blob.blobName)).toEqual(['readme.txt']);
+			expect(result.continuationToken).toBeUndefined();
+		});
+
+		it('downloads blob content with metadata and tags when under the size limit', async () => {
+			const service = new ServiceBlobStorage({ accountName });
+			await service.startUp();
+
+			const result = await service.downloadBlob({
+				containerName: 'member-assets',
+				blobName: 'readme.txt',
+			});
+
+			expect(containerClient.getBlobClient).toHaveBeenCalledWith('readme.txt');
+			expect(result).toEqual({
+				contentType: 'text/plain',
+				contentLength: 5,
+				lastModified: new Date('2026-05-14T12:00:00.000Z'),
+				metadata: { source: 'test' },
+				tags: { env: 'dev' },
+				content: new Uint8Array(Buffer.from('hello')),
+				encoding: 'utf-8',
+				url: 'https://blob.example.test/container/blob.txt',
+			});
+		});
+
+		it('rejects downloads that exceed the in-memory size limit', async () => {
+			getPropertiesMock.mockResolvedValueOnce({
+				contentType: 'application/octet-stream',
+				contentLength: 6 * 1024 * 1024,
+				lastModified: new Date('2026-05-14T12:00:00.000Z'),
+				metadata: {},
+			});
+			const service = new ServiceBlobStorage({ accountName });
+			await service.startUp();
+
+			await expect(
+				service.downloadBlob({
+					containerName: 'member-assets',
+					blobName: 'large.bin',
+				}),
+			).rejects.toThrow(/maximum download size/);
 		});
 
 		it('supports idempotent shutdown before startup', async () => {

--- a/packages/cellix/service-blob-storage/tests/index.test.ts
+++ b/packages/cellix/service-blob-storage/tests/index.test.ts
@@ -280,7 +280,6 @@ describe('@cellix/service-blob-storage public contract', () => {
 			});
 
 			expect(listBlobsByHierarchyMock).toHaveBeenCalledWith('/', {
-				prefix: undefined,
 				includeMetadata: true,
 				includeTags: true,
 			});
@@ -298,6 +297,24 @@ describe('@cellix/service-blob-storage public contract', () => {
 					tags: { env: 'dev' },
 				},
 			]);
+		});
+
+		it('filters blobs by name and metadata on the current hierarchy page', async () => {
+			const service = new ServiceBlobStorage({ accountName });
+			await service.startUp();
+
+			const result = await service.listBlobHierarchy({
+				containerName: 'member-assets',
+				prefix: '',
+				nameContains: 'readme',
+				metadataKey: 'SOURCE',
+				metadataValue: 'TEST',
+				pageSize: 20,
+			});
+
+			expect(findBlobsByTagsMock).not.toHaveBeenCalled();
+			expect(result.folders).toEqual([]);
+			expect(result.blobs.map((blob) => blob.blobName)).toEqual(['readme.txt']);
 		});
 
 		it('filters hierarchy results with blob index tags', async () => {

--- a/packages/ocom-verification/acceptance-api/src/mock-application-services.ts
+++ b/packages/ocom-verification/acceptance-api/src/mock-application-services.ts
@@ -83,6 +83,23 @@ function createNoOpBlobStorageService(): BlobStorageOperations {
 		listBlobs(_request: ListBlobsRequest) {
 			return Promise.resolve([]);
 		},
+		listContainers() {
+			return Promise.resolve([]);
+		},
+		listBlobHierarchy() {
+			return Promise.resolve({ folders: [], blobs: [] });
+		},
+		downloadBlob() {
+			return Promise.resolve({
+				contentType: 'text/plain',
+				contentLength: 0,
+				metadata: {},
+				tags: {},
+				content: new Uint8Array(),
+				encoding: 'utf-8' as const,
+				url: 'https://blob.example.test/no-op',
+			});
+		},
 	};
 }
 
@@ -93,6 +110,9 @@ function createNoOpClientOperationsService(): ClientUploadOperations {
 		},
 		createBlobReadAuthorizationHeader(_request: CreateBlobAuthorizationHeaderRequest): Promise<BlobUploadAuthorizationHeader> {
 			return Promise.resolve(noOpBlobUploadAuthorizationHeader);
+		},
+		generateReadSasToken() {
+			return Promise.resolve('sig=noop');
 		},
 	};
 }

--- a/packages/ocom-verification/e2e-tests/src/servers/test-api-server.ts
+++ b/packages/ocom-verification/e2e-tests/src/servers/test-api-server.ts
@@ -14,5 +14,5 @@ export const testApiServer = new ProcessTestServer({
 	url: apiUrl,
 	// The portless route can reuse a stale local API port from a previous dev run;
 	// clear those fixed listener ports before spinning up the Functions host.
-	portsToCloseBeforeStart: [4280, 7071],
+	portsToCloseBeforeStart: [4280, 4861, 7071],
 });

--- a/packages/ocom-verification/e2e-tests/src/servers/test-api-server.ts
+++ b/packages/ocom-verification/e2e-tests/src/servers/test-api-server.ts
@@ -12,4 +12,7 @@ export const testApiServer = new ProcessTestServer({
 	serverName: 'TestApiServer',
 	spawnArgs: () => ['run', process.env['WORKTREE_NAME'] ? 'dev:worktree' : 'dev'],
 	url: apiUrl,
+	// The portless route can reuse a stale local API port from a previous dev run;
+	// clear those fixed listener ports before spinning up the Functions host.
+	portsToCloseBeforeStart: [4280, 7071],
 });

--- a/packages/ocom-verification/e2e-tests/src/shared/environment/test-environment.test.ts
+++ b/packages/ocom-verification/e2e-tests/src/shared/environment/test-environment.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileSyncMock = vi.hoisted(() => ({
+	fn: vi.fn(),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('node:child_process')>();
+	return {
+		...actual,
+		execFileSync: execFileSyncMock.fn,
+	};
+});
+
+vi.mock('./resolve-portless.ts', () => ({
+	getPortlessPath: () => '/tmp/portless',
+}));
+
+describe('initTestEnvironment', () => {
+	beforeEach(() => {
+		execFileSyncMock.fn.mockReset();
+		process.env.E2E = 'true';
+	});
+
+	it('ignores portless route-lock contention and still starts the proxy', async () => {
+		execFileSyncMock.fn.mockImplementation((command: string, args: string[]) => {
+			if (command === '/tmp/portless' && args[0] === 'prune') {
+				throw new Error('Failed to acquire route lock');
+			}
+			return '';
+		});
+
+		const { cleanupTestEnvironment, initTestEnvironment } = await import('./test-environment.ts');
+		cleanupTestEnvironment();
+		initTestEnvironment();
+
+		expect(execFileSyncMock.fn).toHaveBeenCalledWith(
+			'/tmp/portless',
+			['proxy', 'start', '--https', '-p', '1355'],
+			expect.objectContaining({
+				env: expect.objectContaining({ PORTLESS_WILDCARD: '0' }),
+			}),
+		);
+	});
+});

--- a/packages/ocom-verification/e2e-tests/src/shared/environment/test-environment.ts
+++ b/packages/ocom-verification/e2e-tests/src/shared/environment/test-environment.ts
@@ -41,10 +41,15 @@ export const mockStaffOidcIssuer = buildUrl(hostnames.mockAuth, '/staff-staff-us
 export function initTestEnvironment() {
 	if (proxyInitialized) return;
 
-	execFileSync(getPortlessPath(), ['prune'], {
-		timeout: 10_000,
-		stdio: 'pipe',
-	});
+	try {
+		execFileSync(getPortlessPath(), ['prune'], {
+			timeout: 10_000,
+			stdio: 'pipe',
+		});
+	} catch {
+		// Prune is best-effort cleanup only. A stale route lock does not block the
+		// test proxy from starting, and the next start call will recover cleanly.
+	}
 	try {
 		execFileSync(getPortlessPath(), ['proxy', 'stop', '-p', '1355'], {
 			timeout: 10_000,

--- a/packages/ocom/application-services/src/contexts/tech-admin/blob-list.command-mapper.ts
+++ b/packages/ocom/application-services/src/contexts/tech-admin/blob-list.command-mapper.ts
@@ -1,0 +1,71 @@
+type BlobListQueryInput = {
+	container: string;
+	prefix?: string | null;
+	continuationToken?: string | null;
+	pageSize?: number | null;
+	nameContains?: string | null;
+	metadataKey?: string | null;
+	metadataValue?: string | null;
+	tagKey?: string | null;
+	tagValue?: string | null;
+};
+
+type BlobListQueryCommand = {
+	containerName: string;
+	prefix?: string;
+	continuationToken?: string;
+	pageSize?: number;
+	nameContains?: string;
+	metadataKey?: string;
+	metadataValue?: string;
+	tagKey?: string;
+	tagValue?: string;
+};
+
+function optionalString(value: string | null | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+export function buildBlobListQueryCommand(input: BlobListQueryInput): BlobListQueryCommand {
+	const containerName = input.container?.trim();
+	if (!containerName) {
+		throw new Error('container is required');
+	}
+	const pageSize = input.pageSize ?? undefined;
+	if (pageSize !== undefined && (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100)) {
+		throw new Error('pageSize must be an integer between 1 and 100');
+	}
+
+	const command: BlobListQueryCommand = { containerName };
+	const prefix = optionalString(input.prefix ?? undefined);
+	const continuationToken = optionalString(input.continuationToken ?? undefined);
+	const nameContains = optionalString(input.nameContains ?? undefined);
+	const metadataKey = optionalString(input.metadataKey ?? undefined);
+	const tagKey = optionalString(input.tagKey ?? undefined);
+	if (prefix !== undefined) {
+		command.prefix = prefix;
+	}
+	if (continuationToken !== undefined) {
+		command.continuationToken = continuationToken;
+	}
+	if (pageSize !== undefined) {
+		command.pageSize = pageSize;
+	}
+	if (nameContains !== undefined) {
+		command.nameContains = nameContains;
+	}
+	if (metadataKey !== undefined) {
+		command.metadataKey = metadataKey;
+	}
+	if (input.metadataValue !== null && input.metadataValue !== undefined) {
+		command.metadataValue = input.metadataValue;
+	}
+	if (tagKey !== undefined) {
+		command.tagKey = tagKey;
+	}
+	if (input.tagValue !== null && input.tagValue !== undefined) {
+		command.tagValue = input.tagValue;
+	}
+	return command;
+}

--- a/packages/ocom/application-services/src/contexts/tech-admin/get-blob-content.ts
+++ b/packages/ocom/application-services/src/contexts/tech-admin/get-blob-content.ts
@@ -1,0 +1,59 @@
+import type { BlobAddress, BlobStorageOperations, ClientUploadOperations } from '@ocom/service-blob-storage';
+
+type BlobContentQueryCommand = BlobAddress;
+
+type BlobContentResult = {
+	blobName: string;
+	contentType?: string;
+	contentLength: number;
+	lastModified?: string;
+	metadata: Record<string, string>;
+	tags: Record<string, string>;
+	contentBase64: string;
+	encoding?: 'utf-8' | 'binary';
+	downloadUrl?: string;
+};
+
+export const GetBlobContent = (blobStorageService: BlobStorageOperations, clientOperationsService?: ClientUploadOperations) => {
+	return async (command: BlobContentQueryCommand): Promise<BlobContentResult> => {
+		if (!command.containerName?.trim()) {
+			throw new Error('containerName is required');
+		}
+		if (!command.blobName?.trim()) {
+			throw new Error('blobName is required');
+		}
+
+		const downloaded = await blobStorageService.downloadBlob(command);
+		const contentBase64 = Buffer.from(downloaded.content).toString('base64');
+
+		let downloadUrl = downloaded.url;
+		if (clientOperationsService) {
+			const expiresOn = new Date(Date.now() + 5 * 60 * 1000);
+			const sas = await clientOperationsService.generateReadSasToken({
+				containerName: command.containerName,
+				blobName: command.blobName,
+				expiresOn,
+			});
+			downloadUrl = `${downloaded.url}${downloaded.url.includes('?') ? '&' : '?'}${sas}`;
+		}
+
+		const result: BlobContentResult = {
+			blobName: command.blobName,
+			contentLength: downloaded.contentLength,
+			metadata: downloaded.metadata,
+			tags: downloaded.tags,
+			contentBase64,
+			downloadUrl,
+		};
+		if (downloaded.contentType !== undefined) {
+			result.contentType = downloaded.contentType;
+		}
+		if (downloaded.lastModified !== undefined) {
+			result.lastModified = downloaded.lastModified.toISOString();
+		}
+		if (downloaded.encoding !== undefined) {
+			result.encoding = downloaded.encoding;
+		}
+		return result;
+	};
+};

--- a/packages/ocom/application-services/src/contexts/tech-admin/index.ts
+++ b/packages/ocom/application-services/src/contexts/tech-admin/index.ts
@@ -1,15 +1,27 @@
+import type { BlobStorageOperations, ClientUploadOperations } from '@ocom/service-blob-storage';
+import { GetBlobContent } from './get-blob-content.ts';
+import { ListBlobContainers } from './list-blob-containers.ts';
+import { ListBlobHierarchy } from './list-blob-hierarchy.ts';
 import { ListCollections } from './list-collections.ts';
 import { DatabaseDocuments } from './query-documents.ts';
+
+export { buildBlobListQueryCommand } from './blob-list.command-mapper.ts';
 export { buildDatabaseDocumentsQueryCommand } from './database-documents.command-mapper.ts';
 
 export interface TechAdminApplicationService {
 	ListCollections: ReturnType<typeof ListCollections>;
 	DatabaseDocuments: ReturnType<typeof DatabaseDocuments>;
+	ListBlobContainers: ReturnType<typeof ListBlobContainers>;
+	ListBlobHierarchy: ReturnType<typeof ListBlobHierarchy>;
+	GetBlobContent: ReturnType<typeof GetBlobContent>;
 }
 
-export const TechAdmin = (): TechAdminApplicationService => {
+export const TechAdmin = (blobStorageService: BlobStorageOperations, clientOperationsService?: ClientUploadOperations): TechAdminApplicationService => {
 	return {
 		ListCollections: ListCollections(),
 		DatabaseDocuments: DatabaseDocuments(),
+		ListBlobContainers: ListBlobContainers(blobStorageService),
+		ListBlobHierarchy: ListBlobHierarchy(blobStorageService),
+		GetBlobContent: GetBlobContent(blobStorageService, clientOperationsService),
 	};
 };

--- a/packages/ocom/application-services/src/contexts/tech-admin/list-blob-containers.ts
+++ b/packages/ocom/application-services/src/contexts/tech-admin/list-blob-containers.ts
@@ -1,0 +1,7 @@
+import type { BlobContainerItem, BlobStorageOperations } from '@ocom/service-blob-storage';
+
+export const ListBlobContainers = (blobStorageService: BlobStorageOperations) => {
+	return async (): Promise<BlobContainerItem[]> => {
+		return await blobStorageService.listContainers();
+	};
+};

--- a/packages/ocom/application-services/src/contexts/tech-admin/list-blob-hierarchy.ts
+++ b/packages/ocom/application-services/src/contexts/tech-admin/list-blob-hierarchy.ts
@@ -1,0 +1,10 @@
+import type { BlobHierarchyPage, BlobStorageOperations, ListBlobHierarchyRequest } from '@ocom/service-blob-storage';
+
+export const ListBlobHierarchy = (blobStorageService: BlobStorageOperations) => {
+	return async (command: ListBlobHierarchyRequest): Promise<BlobHierarchyPage> => {
+		if (!command.containerName?.trim()) {
+			throw new Error('containerName is required');
+		}
+		return await blobStorageService.listBlobHierarchy(command);
+	};
+};

--- a/packages/ocom/application-services/src/contexts/user/index.ts
+++ b/packages/ocom/application-services/src/contexts/user/index.ts
@@ -1,8 +1,9 @@
 import type { DataSources } from '@ocom/persistence';
+import type { BlobStorageOperations, ClientUploadOperations } from '@ocom/service-blob-storage';
+import { TechAdmin as TechAdminApi, type TechAdminApplicationService } from '../tech-admin/index.ts';
 import { EndUser as EndUserApi, type EndUserApplicationService } from './end-user/index.ts';
 import { StaffRole as StaffRoleApi, type StaffRoleApplicationService } from './staff-role/index.ts';
 import { StaffUser as StaffUserApi, type StaffUserApplicationService } from './staff-user/index.ts';
-import { TechAdmin as TechAdminApi, type TechAdminApplicationService } from '../tech-admin/index.ts';
 
 export interface UserContextApplicationService {
 	EndUser: EndUserApplicationService;
@@ -11,11 +12,11 @@ export interface UserContextApplicationService {
 	TechAdmin: TechAdminApplicationService;
 }
 
-export const User = (dataSources: DataSources): UserContextApplicationService => {
+export const User = (dataSources: DataSources, blobStorageService: BlobStorageOperations, clientOperationsService?: ClientUploadOperations): UserContextApplicationService => {
 	return {
 		EndUser: EndUserApi(dataSources),
 		StaffRole: StaffRoleApi(dataSources),
 		StaffUser: StaffUserApi(dataSources),
-		TechAdmin: TechAdminApi(),
+		TechAdmin: TechAdminApi(blobStorageService, clientOperationsService),
 	};
 };

--- a/packages/ocom/application-services/src/index.ts
+++ b/packages/ocom/application-services/src/index.ts
@@ -2,11 +2,11 @@ import type { ApiContextSpec } from '@ocom/context-spec';
 import { Domain } from '@ocom/domain';
 import { Community, type CommunityContextApplicationService } from './contexts/community/index.ts';
 import { Service, type ServiceContextApplicationService } from './contexts/service/index.ts';
-import { User, type UserContextApplicationService } from './contexts/user/index.ts';
 import { TechAdmin, type TechAdminApplicationService } from './contexts/tech-admin/index.ts';
+import { User, type UserContextApplicationService } from './contexts/user/index.ts';
 
 export type { CommunityUpdateSettingsCommand } from './contexts/community/index.ts';
-export { buildDatabaseDocumentsQueryCommand } from './contexts/tech-admin/index.ts';
+export { buildBlobListQueryCommand, buildDatabaseDocumentsQueryCommand } from './contexts/tech-admin/index.ts';
 
 export interface ApplicationServices {
 	Community: CommunityContextApplicationService;
@@ -69,15 +69,15 @@ export const buildApplicationServicesFactory = (context: ApiContextSpec): Applic
 			}
 		}
 
-		const { dataSourcesFactory, blobStorageService, queueStorageService } = context;
+		const { dataSourcesFactory, blobStorageService, queueStorageService, clientOperationsService } = context;
 
 		const dataSources = dataSourcesFactory.withPassport(passport);
 
 		return {
 			Community: Community(dataSources, blobStorageService, queueStorageService),
 			Service: Service(dataSources),
-			User: User(dataSources),
-			TechAdmin: TechAdmin(),
+			User: User(dataSources, blobStorageService, clientOperationsService),
+			TechAdmin: TechAdmin(blobStorageService, clientOperationsService),
 			get verifiedUser(): VerifiedUser | null {
 				return { ...tokenValidationResult, hints: hints };
 			},

--- a/packages/ocom/graphql/src/schema/types/features/tech-admin.resolvers.feature
+++ b/packages/ocom/graphql/src/schema/types/features/tech-admin.resolvers.feature
@@ -1,8 +1,8 @@
 Feature: Tech Admin Resolvers Authorization
 
   As a staff portal user
-  I want tech-admin database resolvers to enforce authorization at execution time
-  So that unauthorized users cannot read database collections or documents even if they modify GraphQL queries
+  I want tech-admin resolvers to enforce authorization at execution time
+  So that unauthorized users cannot read database collections, documents, or blob storage even if they modify GraphQL queries
 
   Scenario: Unauthenticated user requests database collections
     Given a user without a verifiedJwt in their context
@@ -41,3 +41,32 @@ Feature: Tech Admin Resolvers Authorization
     And that user has canViewDatabaseDocuments permission
     When the techAdminDatabaseDocuments query is executed with filter containing "$where"
     Then it should throw a "BAD_USER_INPUT" error
+
+  Scenario: Unauthenticated user requests blob containers
+    Given a user without a verifiedJwt in their context
+    When the techAdminBlobContainers query is executed
+    Then it should throw an "Unauthorized" error
+
+  Scenario: Authenticated but unauthorized user requests blob containers
+    Given a user with a verifiedJwt in their context
+    And that user does not have canViewBlobExplorer or canManageTechAdmin permission
+    When the techAdminBlobContainers query is executed
+    Then it should throw an "Unauthorized" error
+
+  Scenario: Authorized user requests blob containers
+    Given a user with a verifiedJwt in their context
+    And that user has canViewBlobExplorer permission
+    When the techAdminBlobContainers query is executed
+    Then it should return blob container names
+
+  Scenario: Authorized user lists blobs with filters
+    Given a user with a verifiedJwt in their context
+    And that user has canViewBlobExplorer permission
+    When the techAdminBlobList query is executed with name and tag filters
+    Then it should return folders and blobs for the selected path
+
+  Scenario: Authorized user previews blob content
+    Given a user with a verifiedJwt in their context
+    And that user has canManageTechAdmin permission
+    When the techAdminBlobContent query is executed
+    Then it should return blob preview content and a download URL

--- a/packages/ocom/graphql/src/schema/types/tech-admin.graphql
+++ b/packages/ocom/graphql/src/schema/types/tech-admin.graphql
@@ -8,7 +8,52 @@ type DatabaseDocumentPage {
 	totalCount: Int!
 }
 
+type BlobKeyValue {
+	key: String!
+	value: String!
+}
+
+type BlobContainer {
+	name: String!
+}
+
+type BlobFolder {
+	name: String!
+	prefix: String!
+}
+
+type BlobExplorerBlob {
+	name: String!
+	blobName: String!
+	contentType: String
+	contentLength: Float!
+	lastModified: String
+	metadata: [BlobKeyValue!]!
+	tags: [BlobKeyValue!]!
+}
+
+type BlobHierarchyPage {
+	folders: [BlobFolder!]!
+	blobs: [BlobExplorerBlob!]!
+	continuationToken: String
+}
+
+type BlobContent {
+	blobName: String!
+	contentType: String
+	contentLength: Float!
+	lastModified: String
+	metadata: [BlobKeyValue!]!
+	tags: [BlobKeyValue!]!
+	contentBase64: String!
+	encoding: String
+	downloadUrl: String
+}
+
 extend type Query {
 	techAdminDatabaseCollections: [String!]!
 	techAdminDatabaseDocuments(collection: String!, filter: String, page: Int, pageSize: Int): DatabaseDocumentPage!
+	techAdminBlobContainers: [BlobContainer!]!
+	techAdminBlobList(container: String!, prefix: String, continuationToken: String, pageSize: Int, nameContains: String, metadataKey: String, metadataValue: String, tagKey: String, tagValue: String): BlobHierarchyPage!
+	techAdminBlobContent(container: String!, blobName: String!): BlobContent!
 }

--- a/packages/ocom/graphql/src/schema/types/tech-admin.resolvers.test.ts
+++ b/packages/ocom/graphql/src/schema/types/tech-admin.resolvers.test.ts
@@ -14,6 +14,7 @@ type MockStaffUser = {
 		permissions?: {
 			techAdminPermissions?: {
 				canViewDatabaseDocuments?: boolean;
+				canViewBlobExplorer?: boolean;
 				canManageTechAdmin?: boolean;
 			};
 		};
@@ -27,6 +28,9 @@ type MockStaffUserService = GraphContext['applicationServices']['User']['StaffUs
 type MockTechAdminService = {
 	ListCollections: ReturnType<typeof vi.fn>;
 	DatabaseDocuments: ReturnType<typeof vi.fn>;
+	ListBlobContainers: ReturnType<typeof vi.fn>;
+	ListBlobHierarchy: ReturnType<typeof vi.fn>;
+	GetBlobContent: ReturnType<typeof vi.fn>;
 };
 
 type TestGraphContext = Omit<GraphContext, 'applicationServices'> & {
@@ -113,6 +117,34 @@ function makeMockGraphContext(options: { jwt?: JwtOverride | null; staffUser?: M
 						totalCount,
 						documents: docs.map((d) => ({ id: String((d as { _id?: unknown })._id), json: JSON.stringify(d) })),
 					};
+				}),
+				ListBlobContainers: vi.fn().mockResolvedValue([{ name: 'member-assets' }, { name: 'private' }]),
+				ListBlobHierarchy: vi.fn().mockResolvedValue({
+					folders: [{ name: 'avatars', prefix: 'avatars/' }],
+					blobs: [
+						{
+							name: 'readme.txt',
+							blobName: 'readme.txt',
+							url: 'https://blob.example.test/member-assets/readme.txt',
+							contentType: 'text/plain',
+							contentLength: 11,
+							lastModified: new Date('2026-05-14T12:00:00.000Z'),
+							metadata: { source: 'seed' },
+							tags: { env: 'dev' },
+						},
+					],
+					continuationToken: undefined,
+				}),
+				GetBlobContent: vi.fn().mockResolvedValue({
+					blobName: 'readme.txt',
+					contentType: 'text/plain',
+					contentLength: 11,
+					lastModified: '2026-05-14T12:00:00.000Z',
+					metadata: { source: 'seed' },
+					tags: { env: 'dev' },
+					contentBase64: Buffer.from('hello world').toString('base64'),
+					encoding: 'utf-8',
+					downloadUrl: 'https://blob.example.test/member-assets/readme.txt?sig=token',
 				}),
 			},
 		},
@@ -656,6 +688,125 @@ describe('techAdminDatabaseCollections', () => {
 		expect(result).toEqual({
 			documents: [],
 			totalCount: 0,
+		});
+	});
+});
+
+describe('techAdminBlobContainers', () => {
+	it('rejects unauthenticated users', async () => {
+		const context = makeMockGraphContext({ jwt: null });
+		await expect(callQuery('techAdminBlobContainers', context)).rejects.toThrow('Unauthorized');
+	});
+
+	it('rejects authenticated users without blob explorer permission', async () => {
+		const context = makeMockGraphContext({
+			staffUser: {
+				role: {
+					permissions: {
+						techAdminPermissions: {
+							canViewDatabaseDocuments: true,
+						},
+					},
+				},
+			},
+		});
+		await expect(callQuery('techAdminBlobContainers', context)).rejects.toThrow('Unauthorized');
+		expect(context.applicationServices.TechAdmin.ListBlobContainers).not.toHaveBeenCalled();
+	});
+
+	it('returns containers for users with canViewBlobExplorer', async () => {
+		const context = makeMockGraphContext({
+			staffUser: {
+				role: {
+					permissions: {
+						techAdminPermissions: {
+							canViewBlobExplorer: true,
+						},
+					},
+				},
+			},
+		});
+		const result = await callQuery('techAdminBlobContainers', context);
+		expect(result).toEqual([{ name: 'member-assets' }, { name: 'private' }]);
+	});
+});
+
+describe('techAdminBlobList', () => {
+	it('lists hierarchy for authorized users and maps metadata/tags', async () => {
+		const context = makeMockGraphContext({
+			staffUser: {
+				role: {
+					permissions: {
+						techAdminPermissions: {
+							canViewBlobExplorer: true,
+						},
+					},
+				},
+			},
+		});
+		const result = await callQuery('techAdminBlobList', context, {
+			container: 'member-assets',
+			nameContains: 'readme',
+			tagKey: 'env',
+			tagValue: 'dev',
+		});
+		expect(context.applicationServices.TechAdmin.ListBlobHierarchy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				containerName: 'member-assets',
+				nameContains: 'readme',
+				tagKey: 'env',
+				tagValue: 'dev',
+			}),
+		);
+		expect(result).toEqual({
+			folders: [{ name: 'avatars', prefix: 'avatars/' }],
+			blobs: [
+				{
+					name: 'readme.txt',
+					blobName: 'readme.txt',
+					contentType: 'text/plain',
+					contentLength: 11,
+					lastModified: '2026-05-14T12:00:00.000Z',
+					metadata: [{ key: 'source', value: 'seed' }],
+					tags: [{ key: 'env', value: 'dev' }],
+				},
+			],
+			continuationToken: null,
+		});
+	});
+});
+
+describe('techAdminBlobContent', () => {
+	it('returns preview content for authorized users', async () => {
+		const context = makeMockGraphContext({
+			staffUser: {
+				role: {
+					permissions: {
+						techAdminPermissions: {
+							canManageTechAdmin: true,
+						},
+					},
+				},
+			},
+		});
+		const result = await callQuery('techAdminBlobContent', context, {
+			container: 'member-assets',
+			blobName: 'readme.txt',
+		});
+		expect(context.applicationServices.TechAdmin.GetBlobContent).toHaveBeenCalledWith({
+			containerName: 'member-assets',
+			blobName: 'readme.txt',
+		});
+		expect(result).toEqual({
+			blobName: 'readme.txt',
+			contentType: 'text/plain',
+			contentLength: 11,
+			lastModified: '2026-05-14T12:00:00.000Z',
+			metadata: [{ key: 'source', value: 'seed' }],
+			tags: [{ key: 'env', value: 'dev' }],
+			contentBase64: Buffer.from('hello world').toString('base64'),
+			encoding: 'utf-8',
+			downloadUrl: 'https://blob.example.test/member-assets/readme.txt?sig=token',
 		});
 	});
 });

--- a/packages/ocom/graphql/src/schema/types/tech-admin.resolvers.ts
+++ b/packages/ocom/graphql/src/schema/types/tech-admin.resolvers.ts
@@ -1,7 +1,7 @@
+import { buildBlobListQueryCommand, buildDatabaseDocumentsQueryCommand } from '@ocom/application-services';
 import { GraphQLError, type GraphQLResolveInfo } from 'graphql';
 import type { Resolvers } from '../builder/generated.ts';
 import type { GraphContext } from '../context.ts';
-import { buildDatabaseDocumentsQueryCommand } from '@ocom/application-services';
 
 function unauthorizedError() {
 	return new GraphQLError('Unauthorized', { extensions: { code: 'UNAUTHENTICATED' } });
@@ -9,6 +9,24 @@ function unauthorizedError() {
 
 function userInputError(message: string) {
 	return new GraphQLError(message, { extensions: { code: 'BAD_USER_INPUT' } });
+}
+
+function recordToKeyValues(record: Record<string, string>): { key: string; value: string }[] {
+	return Object.entries(record).map(([key, value]) => ({ key, value }));
+}
+
+async function assertCanViewBlobExplorer(context: GraphContext): Promise<void> {
+	const jwt = context.applicationServices.verifiedUser?.verifiedJwt;
+	if (!jwt) {
+		throw unauthorizedError();
+	}
+
+	const staff = await context.applicationServices.User.StaffUser.queryByExternalId({ externalId: jwt.sub });
+	const canView = staff?.role?.permissions?.techAdminPermissions?.canViewBlobExplorer === true;
+	const canManage = staff?.role?.permissions?.techAdminPermissions?.canManageTechAdmin === true;
+	if (!canView && !canManage) {
+		throw unauthorizedError();
+	}
 }
 
 const techAdminResolvers: Resolvers = {
@@ -52,6 +70,55 @@ const techAdminResolvers: Resolvers = {
 				}
 			})();
 			return await context.applicationServices.TechAdmin.DatabaseDocuments(command);
+		},
+
+		techAdminBlobContainers: async (_parent: unknown, _args: unknown, context: GraphContext, _info: GraphQLResolveInfo) => {
+			await assertCanViewBlobExplorer(context);
+			return await context.applicationServices.TechAdmin.ListBlobContainers();
+		},
+
+		techAdminBlobList: async (_parent: unknown, args, context: GraphContext, _info: GraphQLResolveInfo) => {
+			await assertCanViewBlobExplorer(context);
+			const command = (() => {
+				try {
+					return buildBlobListQueryCommand(args);
+				} catch (error) {
+					throw userInputError((error as Error).message);
+				}
+			})();
+			const page = await context.applicationServices.TechAdmin.ListBlobHierarchy(command);
+			return {
+				folders: page.folders,
+				blobs: page.blobs.map((blob) => ({
+					name: blob.name,
+					blobName: blob.blobName,
+					contentType: blob.contentType ?? null,
+					contentLength: blob.contentLength,
+					lastModified: blob.lastModified?.toISOString() ?? null,
+					metadata: recordToKeyValues(blob.metadata),
+					tags: recordToKeyValues(blob.tags),
+				})),
+				continuationToken: page.continuationToken ?? null,
+			};
+		},
+
+		techAdminBlobContent: async (_parent: unknown, args: { container: string; blobName: string }, context: GraphContext, _info: GraphQLResolveInfo) => {
+			await assertCanViewBlobExplorer(context);
+			const content = await context.applicationServices.TechAdmin.GetBlobContent({
+				containerName: args.container,
+				blobName: args.blobName,
+			});
+			return {
+				blobName: content.blobName,
+				contentType: content.contentType ?? null,
+				contentLength: content.contentLength,
+				lastModified: content.lastModified ?? null,
+				metadata: recordToKeyValues(content.metadata),
+				tags: recordToKeyValues(content.tags),
+				contentBase64: content.contentBase64,
+				encoding: content.encoding ?? null,
+				downloadUrl: content.downloadUrl ?? null,
+			};
 		},
 	},
 };

--- a/packages/ocom/service-blob-storage/src/blob-storage.contract.ts
+++ b/packages/ocom/service-blob-storage/src/blob-storage.contract.ts
@@ -9,7 +9,7 @@ export type CreateBlobAccessUrlRequest = CreateBlobAuthorizationHeaderRequest;
  * application can depend on only the backend blob methods without redefining
  * their documentation locally.
  */
-export type BlobStorageOperations = Pick<ServiceBlobStorage, 'listBlobs' | 'uploadText' | 'deleteBlob'>;
+export type BlobStorageOperations = Pick<ServiceBlobStorage, 'listBlobs' | 'uploadText' | 'deleteBlob' | 'listContainers' | 'listBlobHierarchy' | 'downloadBlob'>;
 
 /**
  * Client-side blob signing operations.
@@ -17,4 +17,4 @@ export type BlobStorageOperations = Pick<ServiceBlobStorage, 'listBlobs' | 'uplo
  * This is a narrow view of the framework `ServiceClientBlobStorage` class for
  * SharedKey signing workflows used by browser uploads and downloads.
  */
-export type ClientUploadOperations = Pick<ServiceClientBlobStorage, 'createBlobWriteAuthorizationHeader' | 'createBlobReadAuthorizationHeader'>;
+export type ClientUploadOperations = Pick<ServiceClientBlobStorage, 'createBlobWriteAuthorizationHeader' | 'createBlobReadAuthorizationHeader' | 'generateReadSasToken'>;

--- a/packages/ocom/service-blob-storage/src/index.ts
+++ b/packages/ocom/service-blob-storage/src/index.ts
@@ -1,13 +1,20 @@
 export type {
 	BlobAddress,
+	BlobContainerItem,
+	BlobDownloadResult,
+	BlobExplorerItem,
+	BlobFolderItem,
+	BlobHierarchyPage,
 	BlobListItem,
 	ClientBlobStorage,
 	CreateBlobSasUrlRequest,
+	ListBlobHierarchyRequest,
 	ListBlobsRequest,
 	ServiceBlobStorageOptions,
 	ServiceClientBlobStorageOptions,
 	UploadTextBlobRequest,
 } from '@cellix/service-blob-storage';
+export { BLOB_DOWNLOAD_MAX_BYTES } from '@cellix/service-blob-storage';
 export type { BlobStorageOperations, ClientUploadOperations, CreateBlobAccessUrlRequest } from './blob-storage.contract.ts';
 export { ServiceBlobStorage } from './service-blob-storage.ts';
 export { ServiceClientBlobStorage } from './service-client-blob-storage.ts';

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.graphql
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.graphql
@@ -1,6 +1,60 @@
+fragment TechAdminBlobStorageExplorerContainerBlobContainerFields on BlobContainer {
+	name
+}
+
+fragment TechAdminBlobStorageExplorerContainerBlobKeyValueFields on BlobKeyValue {
+	key
+	value
+}
+
+fragment TechAdminBlobStorageExplorerContainerBlobFolderFields on BlobFolder {
+	name
+	prefix
+}
+
+fragment TechAdminBlobStorageExplorerContainerBlobExplorerBlobFields on BlobExplorerBlob {
+	name
+	blobName
+	contentType
+	contentLength
+	lastModified
+	metadata {
+		...TechAdminBlobStorageExplorerContainerBlobKeyValueFields
+	}
+	tags {
+		...TechAdminBlobStorageExplorerContainerBlobKeyValueFields
+	}
+}
+
+fragment TechAdminBlobStorageExplorerContainerBlobContentFields on BlobContent {
+	blobName
+	contentType
+	contentLength
+	lastModified
+	metadata {
+		...TechAdminBlobStorageExplorerContainerBlobKeyValueFields
+	}
+	tags {
+		...TechAdminBlobStorageExplorerContainerBlobKeyValueFields
+	}
+	contentBase64
+	encoding
+	downloadUrl
+}
+
+fragment TechAdminBlobStorageExplorerContainerBlobHierarchyPageFields on BlobHierarchyPage {
+	folders {
+		...TechAdminBlobStorageExplorerContainerBlobFolderFields
+	}
+	blobs {
+		...TechAdminBlobStorageExplorerContainerBlobExplorerBlobFields
+	}
+	continuationToken
+}
+
 query TechAdminBlobStorageExplorerContainers {
 	techAdminBlobContainers {
-		name
+		...TechAdminBlobStorageExplorerContainerBlobContainerFields
 	}
 }
 
@@ -16,45 +70,12 @@ query TechAdminBlobStorageExplorerList($container: String!, $prefix: String, $co
 		tagKey: $tagKey
 		tagValue: $tagValue
 	) {
-		folders {
-			name
-			prefix
-		}
-		blobs {
-			name
-			blobName
-			contentType
-			contentLength
-			lastModified
-			metadata {
-				key
-				value
-			}
-			tags {
-				key
-				value
-			}
-		}
-		continuationToken
+		...TechAdminBlobStorageExplorerContainerBlobHierarchyPageFields
 	}
 }
 
 query TechAdminBlobStorageExplorerContent($container: String!, $blobName: String!) {
 	techAdminBlobContent(container: $container, blobName: $blobName) {
-		blobName
-		contentType
-		contentLength
-		lastModified
-		metadata {
-			key
-			value
-		}
-		tags {
-			key
-			value
-		}
-		contentBase64
-		encoding
-		downloadUrl
+		...TechAdminBlobStorageExplorerContainerBlobContentFields
 	}
 }

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.graphql
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.graphql
@@ -1,0 +1,60 @@
+query TechAdminBlobStorageExplorerContainers {
+	techAdminBlobContainers {
+		name
+	}
+}
+
+query TechAdminBlobStorageExplorerList($container: String!, $prefix: String, $continuationToken: String, $pageSize: Int, $nameContains: String, $metadataKey: String, $metadataValue: String, $tagKey: String, $tagValue: String) {
+	techAdminBlobList(
+		container: $container
+		prefix: $prefix
+		continuationToken: $continuationToken
+		pageSize: $pageSize
+		nameContains: $nameContains
+		metadataKey: $metadataKey
+		metadataValue: $metadataValue
+		tagKey: $tagKey
+		tagValue: $tagValue
+	) {
+		folders {
+			name
+			prefix
+		}
+		blobs {
+			name
+			blobName
+			contentType
+			contentLength
+			lastModified
+			metadata {
+				key
+				value
+			}
+			tags {
+				key
+				value
+			}
+		}
+		continuationToken
+	}
+}
+
+query TechAdminBlobStorageExplorerContent($container: String!, $blobName: String!) {
+	techAdminBlobContent(container: $container, blobName: $blobName) {
+		blobName
+		contentType
+		contentLength
+		lastModified
+		metadata {
+			key
+			value
+		}
+		tags {
+			key
+			value
+		}
+		contentBase64
+		encoding
+		downloadUrl
+	}
+}

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.tsx
@@ -3,24 +3,18 @@ import { ComponentQueryLoader } from '@cellix/ui-core';
 import { Empty } from 'antd';
 import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
-import { TechAdminBlobStorageExplorerContainersDocument, TechAdminBlobStorageExplorerContentDocument, TechAdminBlobStorageExplorerListDocument } from '../generated.tsx';
-import { type BlobExplorerBlob, type BlobExplorerFilters, type BlobPreviewContent, BlobStorageExplorer } from './blob-storage-explorer.tsx';
-
-interface ContainersQueryResult {
-	techAdminBlobContainers: { name: string }[];
-}
-
-interface ListQueryResult {
-	techAdminBlobList: {
-		folders: { name: string; prefix: string }[];
-		blobs: BlobExplorerBlob[];
-		continuationToken?: string | null;
-	};
-}
-
-interface ContentQueryResult {
-	techAdminBlobContent: BlobPreviewContent;
-}
+import {
+	type TechAdminBlobStorageExplorerContainerBlobContentFieldsFragment,
+	type TechAdminBlobStorageExplorerContainerBlobExplorerBlobFieldsFragment,
+	type TechAdminBlobStorageExplorerContainerBlobFolderFieldsFragment,
+	TechAdminBlobStorageExplorerContainersDocument,
+	type TechAdminBlobStorageExplorerContainersQuery,
+	TechAdminBlobStorageExplorerContentDocument,
+	type TechAdminBlobStorageExplorerContentQuery,
+	TechAdminBlobStorageExplorerListDocument,
+	type TechAdminBlobStorageExplorerListQuery,
+} from '../generated.tsx';
+import { type BlobExplorerFilters, BlobStorageExplorer } from './blob-storage-explorer.tsx';
 
 const emptyFilters: BlobExplorerFilters = {
 	nameContains: '',
@@ -34,17 +28,17 @@ export const BlobStorageExplorerContainer: React.FC = () => {
 	const [selectedContainer, setSelectedContainer] = useState<string | undefined>(undefined);
 	const [prefix, setPrefix] = useState('');
 	const [appliedFilters, setAppliedFilters] = useState<BlobExplorerFilters>(emptyFilters);
-	const [accumulatedFolders, setAccumulatedFolders] = useState<{ name: string; prefix: string }[]>([]);
-	const [accumulatedBlobs, setAccumulatedBlobs] = useState<BlobExplorerBlob[]>([]);
+	const [accumulatedFolders, setAccumulatedFolders] = useState<TechAdminBlobStorageExplorerContainerBlobFolderFieldsFragment[]>([]);
+	const [accumulatedBlobs, setAccumulatedBlobs] = useState<TechAdminBlobStorageExplorerContainerBlobExplorerBlobFieldsFragment[]>([]);
 	const [continuationToken, setContinuationToken] = useState<string | null | undefined>(undefined);
-	const [preview, setPreview] = useState<BlobPreviewContent | null>(null);
+	const [preview, setPreview] = useState<TechAdminBlobStorageExplorerContainerBlobContentFieldsFragment | null>(null);
 
 	const {
 		data: containersData,
 		loading: containersLoading,
 		error: containersError,
 		refetch: refetchContainers,
-	} = useQuery<ContainersQueryResult>(TechAdminBlobStorageExplorerContainersDocument, {
+	} = useQuery<TechAdminBlobStorageExplorerContainersQuery>(TechAdminBlobStorageExplorerContainersDocument, {
 		fetchPolicy: 'cache-first',
 	});
 
@@ -62,7 +56,7 @@ export const BlobStorageExplorerContainer: React.FC = () => {
 		[selectedContainer, prefix, appliedFilters],
 	);
 
-	const { loading: listLoading, refetch: refetchList } = useQuery<ListQueryResult>(TechAdminBlobStorageExplorerListDocument, {
+	const { loading: listLoading, refetch: refetchList } = useQuery<TechAdminBlobStorageExplorerListQuery>(TechAdminBlobStorageExplorerListDocument, {
 		variables: listVariables,
 		skip: !selectedContainer,
 		fetchPolicy: 'network-only',
@@ -74,11 +68,11 @@ export const BlobStorageExplorerContainer: React.FC = () => {
 		},
 	});
 
-	const [loadMoreQuery, { loading: loadMoreLoading }] = useLazyQuery<ListQueryResult>(TechAdminBlobStorageExplorerListDocument, {
+	const [loadMoreQuery, { loading: loadMoreLoading }] = useLazyQuery<TechAdminBlobStorageExplorerListQuery>(TechAdminBlobStorageExplorerListDocument, {
 		fetchPolicy: 'network-only',
 	});
 
-	const [loadContent, { loading: previewLoading }] = useLazyQuery<ContentQueryResult>(TechAdminBlobStorageExplorerContentDocument, {
+	const [loadContent, { loading: previewLoading }] = useLazyQuery<TechAdminBlobStorageExplorerContentQuery>(TechAdminBlobStorageExplorerContentDocument, {
 		fetchPolicy: 'network-only',
 	});
 
@@ -131,7 +125,7 @@ export const BlobStorageExplorerContainer: React.FC = () => {
 		setContinuationToken(page.continuationToken);
 	};
 
-	const handleViewBlob = async (blob: BlobExplorerBlob) => {
+	const handleViewBlob = async (blob: TechAdminBlobStorageExplorerContainerBlobExplorerBlobFieldsFragment) => {
 		if (!selectedContainer) {
 			return;
 		}

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.tsx
@@ -1,0 +1,254 @@
+import { gql, useLazyQuery, useQuery } from '@apollo/client';
+import { ComponentQueryLoader } from '@cellix/ui-core';
+import { Empty } from 'antd';
+import type React from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { type BlobExplorerBlob, type BlobExplorerFilters, type BlobPreviewContent, BlobStorageExplorer } from './blob-storage-explorer.tsx';
+
+const CONTAINERS_QUERY = gql`
+query TechAdminBlobStorageExplorerContainers {
+  techAdminBlobContainers {
+    name
+  }
+}
+`;
+
+const LIST_QUERY = gql`
+query TechAdminBlobStorageExplorerList(
+  $container: String!
+  $prefix: String
+  $continuationToken: String
+  $pageSize: Int
+  $nameContains: String
+  $metadataKey: String
+  $metadataValue: String
+  $tagKey: String
+  $tagValue: String
+) {
+  techAdminBlobList(
+    container: $container
+    prefix: $prefix
+    continuationToken: $continuationToken
+    pageSize: $pageSize
+    nameContains: $nameContains
+    metadataKey: $metadataKey
+    metadataValue: $metadataValue
+    tagKey: $tagKey
+    tagValue: $tagValue
+  ) {
+    folders { name prefix }
+    blobs {
+      name
+      blobName
+      contentType
+      contentLength
+      lastModified
+      metadata { key value }
+      tags { key value }
+    }
+    continuationToken
+  }
+}
+`;
+
+const CONTENT_QUERY = gql`
+query TechAdminBlobStorageExplorerContent($container: String!, $blobName: String!) {
+  techAdminBlobContent(container: $container, blobName: $blobName) {
+    blobName
+    contentType
+    contentLength
+    lastModified
+    metadata { key value }
+    tags { key value }
+    contentBase64
+    encoding
+    downloadUrl
+  }
+}
+`;
+
+interface ContainersQueryResult {
+	techAdminBlobContainers: { name: string }[];
+}
+
+interface ListQueryResult {
+	techAdminBlobList: {
+		folders: { name: string; prefix: string }[];
+		blobs: BlobExplorerBlob[];
+		continuationToken?: string | null;
+	};
+}
+
+interface ContentQueryResult {
+	techAdminBlobContent: BlobPreviewContent;
+}
+
+const emptyFilters: BlobExplorerFilters = {
+	nameContains: '',
+	metadataKey: '',
+	metadataValue: '',
+	tagKey: '',
+	tagValue: '',
+};
+
+export const BlobStorageExplorerContainer: React.FC = () => {
+	const [selectedContainer, setSelectedContainer] = useState<string | undefined>(undefined);
+	const [prefix, setPrefix] = useState('');
+	const [draftFilters, setDraftFilters] = useState<BlobExplorerFilters>(emptyFilters);
+	const [appliedFilters, setAppliedFilters] = useState<BlobExplorerFilters>(emptyFilters);
+	const [accumulatedFolders, setAccumulatedFolders] = useState<{ name: string; prefix: string }[]>([]);
+	const [accumulatedBlobs, setAccumulatedBlobs] = useState<BlobExplorerBlob[]>([]);
+	const [continuationToken, setContinuationToken] = useState<string | null | undefined>(undefined);
+	const [preview, setPreview] = useState<BlobPreviewContent | null>(null);
+
+	const {
+		data: containersData,
+		loading: containersLoading,
+		error: containersError,
+		refetch: refetchContainers,
+	} = useQuery<ContainersQueryResult>(CONTAINERS_QUERY, {
+		fetchPolicy: 'cache-first',
+	});
+
+	const listVariables = useMemo(
+		() => ({
+			container: selectedContainer ?? '',
+			prefix: prefix || undefined,
+			pageSize: 50,
+			nameContains: appliedFilters.nameContains || undefined,
+			metadataKey: appliedFilters.metadataKey || undefined,
+			metadataValue: appliedFilters.metadataValue || undefined,
+			tagKey: appliedFilters.tagKey || undefined,
+			tagValue: appliedFilters.tagValue || undefined,
+		}),
+		[selectedContainer, prefix, appliedFilters],
+	);
+
+	const { loading: listLoading, refetch: refetchList } = useQuery<ListQueryResult>(LIST_QUERY, {
+		variables: listVariables,
+		skip: !selectedContainer,
+		fetchPolicy: 'network-only',
+		notifyOnNetworkStatusChange: true,
+		onCompleted: (data) => {
+			setAccumulatedFolders(data.techAdminBlobList.folders);
+			setAccumulatedBlobs(data.techAdminBlobList.blobs);
+			setContinuationToken(data.techAdminBlobList.continuationToken);
+		},
+	});
+
+	const [loadMoreQuery, { loading: loadMoreLoading }] = useLazyQuery<ListQueryResult>(LIST_QUERY, {
+		fetchPolicy: 'network-only',
+	});
+
+	const [loadContent, { loading: previewLoading }] = useLazyQuery<ContentQueryResult>(CONTENT_QUERY, {
+		fetchPolicy: 'network-only',
+	});
+
+	const resetListing = useCallback(() => {
+		setAccumulatedFolders([]);
+		setAccumulatedBlobs([]);
+		setContinuationToken(undefined);
+	}, []);
+
+	const handleSelectContainer = (container: string) => {
+		setSelectedContainer(container);
+		setPrefix('');
+		resetListing();
+	};
+
+	const handleNavigatePrefix = (nextPrefix: string) => {
+		setPrefix(nextPrefix);
+		resetListing();
+	};
+
+	const handleApplyFilters = () => {
+		setAppliedFilters(draftFilters);
+		resetListing();
+	};
+
+	const handleRefresh = async () => {
+		await refetchContainers();
+		if (selectedContainer) {
+			resetListing();
+			await refetchList();
+		}
+	};
+
+	const handleLoadMore = async () => {
+		if (!selectedContainer || !continuationToken) {
+			return;
+		}
+		const result = await loadMoreQuery({
+			variables: {
+				...listVariables,
+				continuationToken,
+			},
+		});
+		const page = result.data?.techAdminBlobList;
+		if (!page) {
+			return;
+		}
+		setAccumulatedFolders((current) => [...current, ...page.folders]);
+		setAccumulatedBlobs((current) => [...current, ...page.blobs]);
+		setContinuationToken(page.continuationToken);
+	};
+
+	const handleViewBlob = async (blob: BlobExplorerBlob) => {
+		if (!selectedContainer) {
+			return;
+		}
+		setPreview(null);
+		const result = await loadContent({
+			variables: {
+				container: selectedContainer,
+				blobName: blob.blobName,
+			},
+		});
+		if (result.data?.techAdminBlobContent) {
+			setPreview(result.data.techAdminBlobContent);
+		}
+	};
+
+	const containers = containersData?.techAdminBlobContainers.map((container) => container.name) ?? [];
+
+	return (
+		<ComponentQueryLoader
+			error={containersError}
+			loading={containersLoading}
+			hasData={containers}
+			hasDataComponent={
+				containers.length === 0 ? (
+					<Empty description="No blob containers available" />
+				) : (
+					<BlobStorageExplorer
+						containers={containers}
+						selectedContainer={selectedContainer}
+						onSelectContainer={handleSelectContainer}
+						prefix={prefix}
+						onNavigatePrefix={handleNavigatePrefix}
+						folders={accumulatedFolders}
+						blobs={accumulatedBlobs}
+						continuationToken={continuationToken}
+						onLoadMore={() => {
+							void handleLoadMore();
+						}}
+						filters={draftFilters}
+						onChangeFilters={setDraftFilters}
+						onApplyFilters={handleApplyFilters}
+						onRefresh={() => {
+							void handleRefresh();
+						}}
+						loading={listLoading || loadMoreLoading}
+						previewLoading={previewLoading}
+						preview={preview}
+						onViewBlob={(blob) => {
+							void handleViewBlob(blob);
+						}}
+						onClosePreview={() => setPreview(null)}
+					/>
+				)
+			}
+			noDataComponent={<Empty description="No blob containers" />}
+		/>
+	);
+};

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.tsx
@@ -1,71 +1,10 @@
-import { gql, useLazyQuery, useQuery } from '@apollo/client';
+import { useLazyQuery, useQuery } from '@apollo/client';
 import { ComponentQueryLoader } from '@cellix/ui-core';
 import { Empty } from 'antd';
 import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
+import { TechAdminBlobStorageExplorerContainersDocument, TechAdminBlobStorageExplorerContentDocument, TechAdminBlobStorageExplorerListDocument } from '../generated.tsx';
 import { type BlobExplorerBlob, type BlobExplorerFilters, type BlobPreviewContent, BlobStorageExplorer } from './blob-storage-explorer.tsx';
-
-const CONTAINERS_QUERY = gql`
-query TechAdminBlobStorageExplorerContainers {
-  techAdminBlobContainers {
-    name
-  }
-}
-`;
-
-const LIST_QUERY = gql`
-query TechAdminBlobStorageExplorerList(
-  $container: String!
-  $prefix: String
-  $continuationToken: String
-  $pageSize: Int
-  $nameContains: String
-  $metadataKey: String
-  $metadataValue: String
-  $tagKey: String
-  $tagValue: String
-) {
-  techAdminBlobList(
-    container: $container
-    prefix: $prefix
-    continuationToken: $continuationToken
-    pageSize: $pageSize
-    nameContains: $nameContains
-    metadataKey: $metadataKey
-    metadataValue: $metadataValue
-    tagKey: $tagKey
-    tagValue: $tagValue
-  ) {
-    folders { name prefix }
-    blobs {
-      name
-      blobName
-      contentType
-      contentLength
-      lastModified
-      metadata { key value }
-      tags { key value }
-    }
-    continuationToken
-  }
-}
-`;
-
-const CONTENT_QUERY = gql`
-query TechAdminBlobStorageExplorerContent($container: String!, $blobName: String!) {
-  techAdminBlobContent(container: $container, blobName: $blobName) {
-    blobName
-    contentType
-    contentLength
-    lastModified
-    metadata { key value }
-    tags { key value }
-    contentBase64
-    encoding
-    downloadUrl
-  }
-}
-`;
 
 interface ContainersQueryResult {
 	techAdminBlobContainers: { name: string }[];
@@ -105,7 +44,7 @@ export const BlobStorageExplorerContainer: React.FC = () => {
 		loading: containersLoading,
 		error: containersError,
 		refetch: refetchContainers,
-	} = useQuery<ContainersQueryResult>(CONTAINERS_QUERY, {
+	} = useQuery<ContainersQueryResult>(TechAdminBlobStorageExplorerContainersDocument, {
 		fetchPolicy: 'cache-first',
 	});
 
@@ -123,7 +62,7 @@ export const BlobStorageExplorerContainer: React.FC = () => {
 		[selectedContainer, prefix, appliedFilters],
 	);
 
-	const { loading: listLoading, refetch: refetchList } = useQuery<ListQueryResult>(LIST_QUERY, {
+	const { loading: listLoading, refetch: refetchList } = useQuery<ListQueryResult>(TechAdminBlobStorageExplorerListDocument, {
 		variables: listVariables,
 		skip: !selectedContainer,
 		fetchPolicy: 'network-only',
@@ -135,11 +74,11 @@ export const BlobStorageExplorerContainer: React.FC = () => {
 		},
 	});
 
-	const [loadMoreQuery, { loading: loadMoreLoading }] = useLazyQuery<ListQueryResult>(LIST_QUERY, {
+	const [loadMoreQuery, { loading: loadMoreLoading }] = useLazyQuery<ListQueryResult>(TechAdminBlobStorageExplorerListDocument, {
 		fetchPolicy: 'network-only',
 	});
 
-	const [loadContent, { loading: previewLoading }] = useLazyQuery<ContentQueryResult>(CONTENT_QUERY, {
+	const [loadContent, { loading: previewLoading }] = useLazyQuery<ContentQueryResult>(TechAdminBlobStorageExplorerContentDocument, {
 		fetchPolicy: 'network-only',
 	});
 

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.container.tsx
@@ -94,7 +94,6 @@ const emptyFilters: BlobExplorerFilters = {
 export const BlobStorageExplorerContainer: React.FC = () => {
 	const [selectedContainer, setSelectedContainer] = useState<string | undefined>(undefined);
 	const [prefix, setPrefix] = useState('');
-	const [draftFilters, setDraftFilters] = useState<BlobExplorerFilters>(emptyFilters);
 	const [appliedFilters, setAppliedFilters] = useState<BlobExplorerFilters>(emptyFilters);
 	const [accumulatedFolders, setAccumulatedFolders] = useState<{ name: string; prefix: string }[]>([]);
 	const [accumulatedBlobs, setAccumulatedBlobs] = useState<BlobExplorerBlob[]>([]);
@@ -161,8 +160,8 @@ export const BlobStorageExplorerContainer: React.FC = () => {
 		resetListing();
 	};
 
-	const handleApplyFilters = () => {
-		setAppliedFilters(draftFilters);
+	const handleApplyFilters = (nextFilters: BlobExplorerFilters) => {
+		setAppliedFilters(nextFilters);
 		resetListing();
 	};
 
@@ -232,8 +231,7 @@ export const BlobStorageExplorerContainer: React.FC = () => {
 						onLoadMore={() => {
 							void handleLoadMore();
 						}}
-						filters={draftFilters}
-						onChangeFilters={setDraftFilters}
+						filters={appliedFilters}
 						onApplyFilters={handleApplyFilters}
 						onRefresh={() => {
 							void handleRefresh();

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.stories.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.stories.tsx
@@ -39,7 +39,6 @@ export const Default = () => (
 			tagKey: '',
 			tagValue: '',
 		}}
-		onChangeFilters={() => undefined}
 		onApplyFilters={() => undefined}
 		onRefresh={() => undefined}
 		preview={null}
@@ -75,7 +74,6 @@ export const WithTextPreview = () => (
 			tagKey: '',
 			tagValue: '',
 		}}
-		onChangeFilters={() => undefined}
 		onApplyFilters={() => undefined}
 		onRefresh={() => undefined}
 		preview={{

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.stories.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.stories.tsx
@@ -1,0 +1,95 @@
+import { BlobStorageExplorer } from './blob-storage-explorer.tsx';
+
+export default { title: 'Tech Admin/Blob Storage Explorer' };
+
+export const Default = () => (
+	<BlobStorageExplorer
+		containers={['member-assets', 'private']}
+		selectedContainer="member-assets"
+		onSelectContainer={() => undefined}
+		prefix="avatars/"
+		onNavigatePrefix={() => undefined}
+		folders={[{ name: 'archived', prefix: 'avatars/archived/' }]}
+		blobs={[
+			{
+				name: 'member-1.png',
+				blobName: 'avatars/member-1.png',
+				contentType: 'image/png',
+				contentLength: 2048,
+				lastModified: '2026-05-14T12:00:00.000Z',
+				metadata: [{ key: 'source', value: 'upload' }],
+				tags: [{ key: 'env', value: 'dev' }],
+			},
+			{
+				name: 'notes.json',
+				blobName: 'avatars/notes.json',
+				contentType: 'application/json',
+				contentLength: 42,
+				lastModified: '2026-05-14T13:00:00.000Z',
+				metadata: [],
+				tags: [],
+			},
+		]}
+		continuationToken="next"
+		onLoadMore={() => undefined}
+		filters={{
+			nameContains: '',
+			metadataKey: '',
+			metadataValue: '',
+			tagKey: '',
+			tagValue: '',
+		}}
+		onChangeFilters={() => undefined}
+		onApplyFilters={() => undefined}
+		onRefresh={() => undefined}
+		preview={null}
+		onViewBlob={() => undefined}
+		onClosePreview={() => undefined}
+	/>
+);
+
+export const WithTextPreview = () => (
+	<BlobStorageExplorer
+		containers={['member-assets']}
+		selectedContainer="member-assets"
+		onSelectContainer={() => undefined}
+		prefix=""
+		onNavigatePrefix={() => undefined}
+		folders={[]}
+		blobs={[
+			{
+				name: 'readme.txt',
+				blobName: 'readme.txt',
+				contentType: 'text/plain',
+				contentLength: 11,
+				lastModified: '2026-05-14T12:00:00.000Z',
+				metadata: [],
+				tags: [],
+			},
+		]}
+		onLoadMore={() => undefined}
+		filters={{
+			nameContains: '',
+			metadataKey: '',
+			metadataValue: '',
+			tagKey: '',
+			tagValue: '',
+		}}
+		onChangeFilters={() => undefined}
+		onApplyFilters={() => undefined}
+		onRefresh={() => undefined}
+		preview={{
+			blobName: 'readme.txt',
+			contentType: 'text/plain',
+			contentLength: 11,
+			lastModified: '2026-05-14T12:00:00.000Z',
+			metadata: [{ key: 'source', value: 'seed' }],
+			tags: [{ key: 'env', value: 'dev' }],
+			contentBase64: btoa('hello world'),
+			encoding: 'utf-8',
+			downloadUrl: null,
+		}}
+		onViewBlob={() => undefined}
+		onClosePreview={() => undefined}
+	/>
+);

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.test.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.test.tsx
@@ -29,7 +29,6 @@ const baseProps = {
 		tagKey: '',
 		tagValue: '',
 	},
-	onChangeFilters: () => undefined,
 	onApplyFilters: () => undefined,
 	onRefresh: () => undefined,
 	preview: null,
@@ -82,33 +81,36 @@ test('invokes view action for a blob', () => {
 });
 
 test('applies filters from the filter inputs', () => {
-	const onChangeFilters = vi.fn();
 	const onApplyFilters = vi.fn();
 	render(
 		<BlobStorageExplorer
 			{...baseProps}
-			onChangeFilters={onChangeFilters}
 			onApplyFilters={onApplyFilters}
 		/>,
 	);
 
 	const nameInputs = screen.getAllByLabelText('Filter by blob name');
+	const metadataKeyInputs = screen.getAllByLabelText('Filter by metadata key');
+	const metadataValueInputs = screen.getAllByLabelText('Filter by metadata value');
 	const tagKeyInputs = screen.getAllByLabelText('Filter by tag key');
 	const tagValueInputs = screen.getAllByLabelText('Filter by tag value');
 	const applyButtons = screen.getAllByText('Apply filters');
 	fireEvent.change(nameInputs[nameInputs.length - 1], { target: { value: 'readme' } });
+	fireEvent.change(metadataKeyInputs[metadataKeyInputs.length - 1], { target: { value: 'source' } });
+	fireEvent.change(metadataValueInputs[metadataValueInputs.length - 1], { target: { value: 'seed' } });
 	fireEvent.change(tagKeyInputs[tagKeyInputs.length - 1], { target: { value: 'env' } });
 	fireEvent.change(tagValueInputs[tagValueInputs.length - 1], { target: { value: 'dev' } });
 	fireEvent.click(applyButtons[applyButtons.length - 1]);
 
-	expect(onChangeFilters).toHaveBeenCalledWith(
+	expect(onApplyFilters).toHaveBeenCalledWith(
 		expect.objectContaining({
 			nameContains: 'readme',
+			metadataKey: 'source',
+			metadataValue: 'seed',
 			tagKey: 'env',
 			tagValue: 'dev',
 		}),
 	);
-	expect(onApplyFilters).toHaveBeenCalled();
 });
 
 test('shows preview content and download action', () => {
@@ -131,4 +133,44 @@ test('shows preview content and download action', () => {
 
 	expect(screen.getAllByText('hello world').length).toBeGreaterThan(0);
 	expect(screen.getAllByLabelText('Download blob').length).toBeGreaterThan(0);
+});
+
+test('downloads the original blob from preview content', () => {
+	const createObjectURL = vi.fn(() => 'blob:download');
+	const revokeObjectURL = vi.fn();
+	Object.defineProperty(globalThis.URL, 'createObjectURL', { value: createObjectURL, configurable: true });
+	Object.defineProperty(globalThis.URL, 'revokeObjectURL', { value: revokeObjectURL, configurable: true });
+
+	const clickMock = vi.fn();
+	const originalCreateElement = document.createElement.bind(document);
+	vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+		const element = originalCreateElement(tagName);
+		if (tagName === 'a') {
+			element.click = clickMock;
+		}
+		return element;
+	});
+
+	render(
+		<BlobStorageExplorer
+			{...baseProps}
+			preview={{
+				blobName: 'avatars/member-1.png',
+				contentType: 'image/png',
+				contentLength: 5,
+				lastModified: '2026-05-14T12:00:00.000Z',
+				metadata: [],
+				tags: [],
+				contentBase64: btoa('hello'),
+				encoding: 'binary',
+				downloadUrl: 'https://blob.example.test/member-assets/avatars/member-1.png?sig=token',
+			}}
+		/>,
+	);
+
+	fireEvent.click(screen.getAllByLabelText('Download blob')[0]);
+
+	expect(createObjectURL).toHaveBeenCalled();
+	expect(clickMock).toHaveBeenCalled();
+	expect(revokeObjectURL).toHaveBeenCalledWith('blob:download');
 });

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.test.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { BlobStorageExplorer } from './blob-storage-explorer.tsx';
+
+const baseProps = {
+	containers: ['member-assets'],
+	selectedContainer: 'member-assets',
+	onSelectContainer: () => undefined,
+	prefix: '',
+	onNavigatePrefix: () => undefined,
+	folders: [{ name: 'avatars', prefix: 'avatars/' }],
+	blobs: [
+		{
+			name: 'readme.txt',
+			blobName: 'readme.txt',
+			contentType: 'text/plain',
+			contentLength: 11,
+			lastModified: '2026-05-14T12:00:00.000Z',
+			metadata: [{ key: 'source', value: 'seed' }],
+			tags: [{ key: 'env', value: 'dev' }],
+		},
+	],
+	continuationToken: undefined as string | undefined,
+	onLoadMore: () => undefined,
+	filters: {
+		nameContains: '',
+		metadataKey: '',
+		metadataValue: '',
+		tagKey: '',
+		tagValue: '',
+	},
+	onChangeFilters: () => undefined,
+	onApplyFilters: () => undefined,
+	onRefresh: () => undefined,
+	preview: null,
+	onViewBlob: () => undefined,
+	onClosePreview: () => undefined,
+};
+
+test('renders blob storage explorer title and listing', () => {
+	render(<BlobStorageExplorer {...baseProps} />);
+
+	expect(screen.getByText(/Blob Storage Explorer/i)).toBeTruthy();
+	expect(screen.getAllByText('avatars/').length).toBeGreaterThan(0);
+	expect(screen.getAllByText('readme.txt').length).toBeGreaterThan(0);
+	expect(screen.getAllByText('text/plain').length).toBeGreaterThan(0);
+	expect(screen.getAllByText('source=seed').length).toBeGreaterThan(0);
+	expect(screen.getAllByText('env=dev').length).toBeGreaterThan(0);
+});
+
+test('navigates into a folder when folder name is clicked', () => {
+	const onNavigatePrefix = vi.fn();
+	render(
+		<BlobStorageExplorer
+			{...baseProps}
+			onNavigatePrefix={onNavigatePrefix}
+		/>,
+	);
+
+	const folderLinks = screen.getAllByText('avatars/');
+	fireEvent.click(folderLinks[folderLinks.length - 1]);
+	expect(onNavigatePrefix).toHaveBeenCalledWith('avatars/');
+});
+
+test('invokes view action for a blob', () => {
+	const onViewBlob = vi.fn();
+	render(
+		<BlobStorageExplorer
+			{...baseProps}
+			onViewBlob={onViewBlob}
+		/>,
+	);
+
+	const viewButtons = screen.getAllByLabelText('View blob readme.txt');
+	fireEvent.click(viewButtons[viewButtons.length - 1]);
+	expect(onViewBlob).toHaveBeenCalledWith(
+		expect.objectContaining({
+			blobName: 'readme.txt',
+			contentType: 'text/plain',
+		}),
+	);
+});
+
+test('applies filters from the filter inputs', () => {
+	const onChangeFilters = vi.fn();
+	const onApplyFilters = vi.fn();
+	render(
+		<BlobStorageExplorer
+			{...baseProps}
+			onChangeFilters={onChangeFilters}
+			onApplyFilters={onApplyFilters}
+		/>,
+	);
+
+	const nameInputs = screen.getAllByLabelText('Filter by blob name');
+	const tagKeyInputs = screen.getAllByLabelText('Filter by tag key');
+	const tagValueInputs = screen.getAllByLabelText('Filter by tag value');
+	const applyButtons = screen.getAllByText('Apply filters');
+	fireEvent.change(nameInputs[nameInputs.length - 1], { target: { value: 'readme' } });
+	fireEvent.change(tagKeyInputs[tagKeyInputs.length - 1], { target: { value: 'env' } });
+	fireEvent.change(tagValueInputs[tagValueInputs.length - 1], { target: { value: 'dev' } });
+	fireEvent.click(applyButtons[applyButtons.length - 1]);
+
+	expect(onChangeFilters).toHaveBeenCalledWith(
+		expect.objectContaining({
+			nameContains: 'readme',
+			tagKey: 'env',
+			tagValue: 'dev',
+		}),
+	);
+	expect(onApplyFilters).toHaveBeenCalled();
+});
+
+test('shows preview content and download action', () => {
+	render(
+		<BlobStorageExplorer
+			{...baseProps}
+			preview={{
+				blobName: 'readme.txt',
+				contentType: 'text/plain',
+				contentLength: 11,
+				lastModified: '2026-05-14T12:00:00.000Z',
+				metadata: [],
+				tags: [],
+				contentBase64: btoa('hello world'),
+				encoding: 'utf-8',
+				downloadUrl: null,
+			}}
+		/>,
+	);
+
+	expect(screen.getAllByText('hello world').length).toBeGreaterThan(0);
+	expect(screen.getAllByLabelText('Download blob').length).toBeGreaterThan(0);
+});

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.tsx
@@ -1,0 +1,507 @@
+import { CloudServerOutlined, DownloadOutlined, EyeOutlined, FolderOutlined, ReloadOutlined } from '@ant-design/icons';
+import type { TableColumnsType } from 'antd';
+import { Breadcrumb, Button, Input, Modal, Select, Space, Table, Tag, Typography } from 'antd';
+import type React from 'react';
+import { useMemo, useState } from 'react';
+
+const { Title, Text, Paragraph } = Typography;
+
+type BlobKeyValue = { key: string; value: string };
+
+type BlobExplorerFolder = {
+	name: string;
+	prefix: string;
+};
+
+export type BlobExplorerBlob = {
+	name: string;
+	blobName: string;
+	contentType?: string | null | undefined;
+	contentLength: number;
+	lastModified?: string | null | undefined;
+	metadata: BlobKeyValue[];
+	tags: BlobKeyValue[];
+};
+
+export type BlobPreviewContent = {
+	blobName: string;
+	contentType?: string | null;
+	contentLength: number;
+	lastModified?: string | null;
+	metadata: BlobKeyValue[];
+	tags: BlobKeyValue[];
+	contentBase64: string;
+	encoding?: string | null;
+	downloadUrl?: string | null;
+};
+
+export type BlobExplorerFilters = {
+	nameContains: string;
+	metadataKey: string;
+	metadataValue: string;
+	tagKey: string;
+	tagValue: string;
+};
+
+interface BlobStorageExplorerProps {
+	containers: string[];
+	selectedContainer?: string | undefined;
+	onSelectContainer: (container: string) => void;
+	prefix: string;
+	onNavigatePrefix: (prefix: string) => void;
+	folders: BlobExplorerFolder[];
+	blobs: BlobExplorerBlob[];
+	continuationToken?: string | null | undefined;
+	onLoadMore: () => void;
+	filters: BlobExplorerFilters;
+	onChangeFilters: (filters: BlobExplorerFilters) => void;
+	onApplyFilters: () => void;
+	onRefresh: () => void;
+	loading?: boolean | undefined;
+	previewLoading?: boolean | undefined;
+	preview?: BlobPreviewContent | null | undefined;
+	onViewBlob: (blob: BlobExplorerBlob) => void;
+	onClosePreview: () => void;
+}
+
+function formatBytes(bytes: number): string {
+	if (!Number.isFinite(bytes) || bytes < 0) {
+		return '—';
+	}
+	if (bytes < 1024) {
+		return `${bytes} B`;
+	}
+	const units = ['KB', 'MB', 'GB', 'TB'];
+	let value = bytes / 1024;
+	let unitIndex = 0;
+	while (value >= 1024 && unitIndex < units.length - 1) {
+		value /= 1024;
+		unitIndex += 1;
+	}
+	return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function formatKeyValues(entries: BlobKeyValue[]): React.ReactNode {
+	if (entries.length === 0) {
+		return <Text type="secondary">—</Text>;
+	}
+	return (
+		<Space
+			size={[4, 4]}
+			wrap
+		>
+			{entries.map((entry) => (
+				<Tag key={`${entry.key}:${entry.value}`}>
+					{entry.key}={entry.value}
+				</Tag>
+			))}
+		</Space>
+	);
+}
+
+function decodePreviewText(contentBase64: string): string {
+	try {
+		const binary = atob(contentBase64);
+		const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+		return new TextDecoder().decode(bytes);
+	} catch {
+		return '[Unable to decode text content]';
+	}
+}
+
+function isImageContentType(contentType: string | null | undefined): boolean {
+	return Boolean(contentType?.toLowerCase().startsWith('image/'));
+}
+
+function isPdfContentType(contentType: string | null | undefined): boolean {
+	return contentType?.toLowerCase().startsWith('application/pdf') === true;
+}
+
+function isTextPreview(contentType: string | null | undefined, encoding: string | null | undefined): boolean {
+	if (encoding === 'utf-8') {
+		return true;
+	}
+	if (!contentType) {
+		return false;
+	}
+	const normalized = contentType.toLowerCase().split(';')[0]?.trim() ?? '';
+	return normalized.startsWith('text/') || normalized === 'application/json' || normalized === 'application/xml' || normalized.endsWith('+json') || normalized.endsWith('+xml');
+}
+
+type TableRow =
+	| { key: string; kind: 'folder'; name: string; prefix: string }
+	| {
+			key: string;
+			kind: 'blob';
+			name: string;
+			blobName: string;
+			contentType?: string | null | undefined;
+			contentLength: number;
+			lastModified?: string | null | undefined;
+			metadata: BlobKeyValue[];
+			tags: BlobKeyValue[];
+	  };
+
+export const BlobStorageExplorer: React.FC<BlobStorageExplorerProps> = ({
+	containers,
+	selectedContainer,
+	onSelectContainer,
+	prefix,
+	onNavigatePrefix,
+	folders,
+	blobs,
+	continuationToken,
+	onLoadMore,
+	filters,
+	onChangeFilters,
+	onApplyFilters,
+	onRefresh,
+	loading,
+	previewLoading,
+	preview,
+	onViewBlob,
+	onClosePreview,
+}) => {
+	const [draftFilters, setDraftFilters] = useState(filters);
+
+	const breadcrumbItems = useMemo(() => {
+		const segments = prefix.split('/').filter(Boolean);
+		const items = [
+			{
+				title: (
+					<Button
+						type="link"
+						onClick={() => onNavigatePrefix('')}
+						style={{ padding: 0 }}
+					>
+						{selectedContainer || 'Container'}
+					</Button>
+				),
+			},
+		];
+		segments.forEach((segment, index) => {
+			const nextPrefix = `${segments.slice(0, index + 1).join('/')}/`;
+			items.push({
+				title: (
+					<Button
+						type="link"
+						onClick={() => onNavigatePrefix(nextPrefix)}
+						style={{ padding: 0 }}
+					>
+						{segment}
+					</Button>
+				),
+			});
+		});
+		return items;
+	}, [onNavigatePrefix, prefix, selectedContainer]);
+
+	const rows: TableRow[] = [
+		...folders.map((folder) => ({
+			key: `folder:${folder.prefix}`,
+			kind: 'folder' as const,
+			name: folder.name,
+			prefix: folder.prefix,
+		})),
+		...blobs.map((blob) => ({
+			key: `blob:${blob.blobName}`,
+			kind: 'blob' as const,
+			name: blob.name,
+			blobName: blob.blobName,
+			contentType: blob.contentType,
+			contentLength: blob.contentLength,
+			lastModified: blob.lastModified,
+			metadata: blob.metadata,
+			tags: blob.tags,
+		})),
+	];
+
+	const columns: TableColumnsType<TableRow> = [
+		{
+			title: 'Name',
+			dataIndex: 'name',
+			key: 'name',
+			render: (_value, record) =>
+				record.kind === 'folder' ? (
+					<Button
+						type="link"
+						icon={<FolderOutlined />}
+						onClick={() => onNavigatePrefix(record.prefix)}
+						style={{ paddingInline: 0 }}
+					>
+						{record.name}/
+					</Button>
+				) : (
+					<span>{record.name}</span>
+				),
+		},
+		{
+			title: 'Content type',
+			key: 'contentType',
+			render: (_value, record) => (record.kind === 'blob' ? (record.contentType ?? '—') : 'folder'),
+		},
+		{
+			title: 'Size',
+			key: 'size',
+			render: (_value, record) => (record.kind === 'blob' ? formatBytes(record.contentLength) : '—'),
+		},
+		{
+			title: 'Last modified',
+			key: 'lastModified',
+			render: (_value, record) => (record.kind === 'blob' && record.lastModified ? new Date(record.lastModified).toLocaleString() : '—'),
+		},
+		{
+			title: 'Tags',
+			key: 'tags',
+			render: (_value, record) => (record.kind === 'blob' ? formatKeyValues(record.tags) : '—'),
+		},
+		{
+			title: 'Metadata',
+			key: 'metadata',
+			render: (_value, record) => (record.kind === 'blob' ? formatKeyValues(record.metadata) : '—'),
+		},
+		{
+			title: 'Actions',
+			key: 'actions',
+			render: (_value, record) =>
+				record.kind === 'blob' ? (
+					<Button
+						aria-label={`View blob ${record.blobName}`}
+						icon={<EyeOutlined />}
+						size="small"
+						type="link"
+						onClick={() =>
+							onViewBlob({
+								name: record.name,
+								blobName: record.blobName,
+								contentType: record.contentType,
+								contentLength: record.contentLength,
+								lastModified: record.lastModified,
+								metadata: record.metadata,
+								tags: record.tags,
+							})
+						}
+					>
+						View
+					</Button>
+				) : null,
+		},
+	];
+
+	const previewObjectUrl = useMemo(() => {
+		if (!preview?.contentBase64) {
+			return null;
+		}
+		if (!isImageContentType(preview.contentType) && !isPdfContentType(preview.contentType)) {
+			return null;
+		}
+		const binary = atob(preview.contentBase64);
+		const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+		const blob = new Blob([bytes], { type: preview.contentType ?? 'application/octet-stream' });
+		return URL.createObjectURL(blob);
+	}, [preview]);
+
+	const handleDownload = () => {
+		if (!preview) {
+			return;
+		}
+		if (preview.downloadUrl) {
+			const anchor = document.createElement('a');
+			anchor.href = preview.downloadUrl;
+			anchor.download = preview.blobName.split('/').pop() ?? preview.blobName;
+			anchor.rel = 'noopener';
+			anchor.target = '_blank';
+			anchor.click();
+			return;
+		}
+		const binary = atob(preview.contentBase64);
+		const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+		const blob = new Blob([bytes], { type: preview.contentType ?? 'application/octet-stream' });
+		const url = URL.createObjectURL(blob);
+		const anchor = document.createElement('a');
+		anchor.href = url;
+		anchor.download = preview.blobName.split('/').pop() ?? preview.blobName;
+		anchor.click();
+		URL.revokeObjectURL(url);
+	};
+
+	return (
+		<Space
+			direction="vertical"
+			style={{ width: '100%' }}
+			size="large"
+		>
+			<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+				<Title
+					level={3}
+					style={{ margin: 0 }}
+				>
+					Blob Storage Explorer
+				</Title>
+				<Button
+					icon={<ReloadOutlined />}
+					onClick={onRefresh}
+					disabled={!selectedContainer}
+				>
+					Refresh
+				</Button>
+			</div>
+
+			<div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+				<Select<string>
+					style={{ minWidth: 240 }}
+					size="large"
+					placeholder="Select container"
+					value={selectedContainer ?? null}
+					onChange={onSelectContainer}
+					options={containers.map((container) => ({ label: container, value: container }))}
+					suffixIcon={<CloudServerOutlined />}
+				/>
+				<Input
+					style={{ width: 180 }}
+					placeholder="Name contains"
+					value={draftFilters.nameContains}
+					onChange={(event) => setDraftFilters({ ...draftFilters, nameContains: event.target.value })}
+					aria-label="Filter by blob name"
+				/>
+				<Input
+					style={{ width: 140 }}
+					placeholder="Metadata key"
+					value={draftFilters.metadataKey}
+					onChange={(event) => setDraftFilters({ ...draftFilters, metadataKey: event.target.value })}
+					aria-label="Filter by metadata key"
+				/>
+				<Input
+					style={{ width: 140 }}
+					placeholder="Metadata value"
+					value={draftFilters.metadataValue}
+					onChange={(event) => setDraftFilters({ ...draftFilters, metadataValue: event.target.value })}
+					aria-label="Filter by metadata value"
+				/>
+				<Input
+					style={{ width: 120 }}
+					placeholder="Tag key"
+					value={draftFilters.tagKey}
+					onChange={(event) => setDraftFilters({ ...draftFilters, tagKey: event.target.value })}
+					aria-label="Filter by tag key"
+				/>
+				<Input
+					style={{ width: 120 }}
+					placeholder="Tag value"
+					value={draftFilters.tagValue}
+					onChange={(event) => setDraftFilters({ ...draftFilters, tagValue: event.target.value })}
+					aria-label="Filter by tag value"
+				/>
+				<Button
+					type="primary"
+					size="large"
+					onClick={() => {
+						onChangeFilters(draftFilters);
+						onApplyFilters();
+					}}
+				>
+					Apply filters
+				</Button>
+			</div>
+
+			{selectedContainer ? <Breadcrumb items={breadcrumbItems} /> : null}
+
+			<Table<TableRow>
+				dataSource={rows}
+				columns={columns}
+				rowKey="key"
+				loading={!!loading}
+				pagination={false}
+			/>
+
+			{continuationToken ? (
+				<div style={{ display: 'flex', justifyContent: 'center' }}>
+					<Button
+						onClick={onLoadMore}
+						loading={!!loading}
+					>
+						Load more
+					</Button>
+				</div>
+			) : null}
+
+			<Modal
+				open={Boolean(preview) || !!previewLoading}
+				title={preview?.blobName ?? 'Blob preview'}
+				onCancel={onClosePreview}
+				footer={[
+					<Button
+						key="close"
+						onClick={onClosePreview}
+					>
+						Close
+					</Button>,
+					<Button
+						key="download"
+						type="primary"
+						icon={<DownloadOutlined />}
+						onClick={handleDownload}
+						disabled={!preview}
+						aria-label="Download blob"
+					>
+						Download
+					</Button>,
+				]}
+				width="80vw"
+				style={{ top: 24 }}
+			>
+				{previewLoading && !preview ? <Paragraph>Loading preview…</Paragraph> : null}
+				{preview ? (
+					<Space
+						direction="vertical"
+						style={{ width: '100%' }}
+						size="middle"
+					>
+						<Text type="secondary">
+							{preview.contentType ?? 'unknown type'} · {formatBytes(preview.contentLength)}
+							{preview.lastModified ? ` · ${new Date(preview.lastModified).toLocaleString()}` : ''}
+						</Text>
+						<div>
+							<Text strong>Tags</Text>
+							<div>{formatKeyValues(preview.tags)}</div>
+						</div>
+						<div>
+							<Text strong>Metadata</Text>
+							<div>{formatKeyValues(preview.metadata)}</div>
+						</div>
+						{isImageContentType(preview.contentType) && previewObjectUrl ? (
+							<img
+								src={previewObjectUrl}
+								alt={preview.blobName}
+								style={{ maxWidth: '100%', maxHeight: '60vh', objectFit: 'contain' }}
+							/>
+						) : null}
+						{isPdfContentType(preview.contentType) && previewObjectUrl ? (
+							<iframe
+								title={preview.blobName}
+								src={previewObjectUrl}
+								style={{ width: '100%', height: '60vh', border: 'none' }}
+							/>
+						) : null}
+						{isTextPreview(preview.contentType, preview.encoding) ? (
+							<pre
+								style={{
+									whiteSpace: 'pre-wrap',
+									overflow: 'auto',
+									maxHeight: '60vh',
+									margin: 0,
+									fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+								}}
+							>
+								{decodePreviewText(preview.contentBase64)}
+							</pre>
+						) : null}
+						{!isImageContentType(preview.contentType) && !isPdfContentType(preview.contentType) && !isTextPreview(preview.contentType, preview.encoding) ? (
+							<Paragraph type="secondary">Preview is not available for this content type. Use Download to save the original blob.</Paragraph>
+						) : null}
+					</Space>
+				) : null}
+			</Modal>
+		</Space>
+	);
+};

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.tsx
@@ -54,8 +54,7 @@ interface BlobStorageExplorerProps {
 	continuationToken?: string | null | undefined;
 	onLoadMore: () => void;
 	filters: BlobExplorerFilters;
-	onChangeFilters: (filters: BlobExplorerFilters) => void;
-	onApplyFilters: () => void;
+	onApplyFilters: (filters: BlobExplorerFilters) => void;
 	onRefresh: () => void;
 	loading?: boolean | undefined;
 	previewLoading?: boolean | undefined;
@@ -153,7 +152,6 @@ export const BlobStorageExplorer: React.FC<BlobStorageExplorerProps> = ({
 	continuationToken,
 	onLoadMore,
 	filters,
-	onChangeFilters,
 	onApplyFilters,
 	onRefresh,
 	loading,
@@ -305,15 +303,6 @@ export const BlobStorageExplorer: React.FC<BlobStorageExplorerProps> = ({
 		if (!preview) {
 			return;
 		}
-		if (preview.downloadUrl) {
-			const anchor = document.createElement('a');
-			anchor.href = preview.downloadUrl;
-			anchor.download = preview.blobName.split('/').pop() ?? preview.blobName;
-			anchor.rel = 'noopener';
-			anchor.target = '_blank';
-			anchor.click();
-			return;
-		}
 		const binary = atob(preview.contentBase64);
 		const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
 		const blob = new Blob([bytes], { type: preview.contentType ?? 'application/octet-stream' });
@@ -321,7 +310,9 @@ export const BlobStorageExplorer: React.FC<BlobStorageExplorerProps> = ({
 		const anchor = document.createElement('a');
 		anchor.href = url;
 		anchor.download = preview.blobName.split('/').pop() ?? preview.blobName;
+		document.body.appendChild(anchor);
 		anchor.click();
+		anchor.remove();
 		URL.revokeObjectURL(url);
 	};
 
@@ -395,10 +386,7 @@ export const BlobStorageExplorer: React.FC<BlobStorageExplorerProps> = ({
 				<Button
 					type="primary"
 					size="large"
-					onClick={() => {
-						onChangeFilters(draftFilters);
-						onApplyFilters();
-					}}
+					onClick={() => onApplyFilters(draftFilters)}
 				>
 					Apply filters
 				</Button>

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.tsx
@@ -3,37 +3,19 @@ import type { TableColumnsType } from 'antd';
 import { Breadcrumb, Button, Input, Modal, Select, Space, Table, Tag, Typography } from 'antd';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
+import type {
+	TechAdminBlobStorageExplorerContainerBlobContentFieldsFragment,
+	TechAdminBlobStorageExplorerContainerBlobExplorerBlobFieldsFragment,
+	TechAdminBlobStorageExplorerContainerBlobFolderFieldsFragment,
+	TechAdminBlobStorageExplorerContainerBlobKeyValueFieldsFragment,
+} from '../generated.tsx';
 
 const { Title, Text, Paragraph } = Typography;
 
-type BlobKeyValue = { key: string; value: string };
-
-type BlobExplorerFolder = {
-	name: string;
-	prefix: string;
-};
-
-export type BlobExplorerBlob = {
-	name: string;
-	blobName: string;
-	contentType?: string | null | undefined;
-	contentLength: number;
-	lastModified?: string | null | undefined;
-	metadata: BlobKeyValue[];
-	tags: BlobKeyValue[];
-};
-
-export type BlobPreviewContent = {
-	blobName: string;
-	contentType?: string | null;
-	contentLength: number;
-	lastModified?: string | null;
-	metadata: BlobKeyValue[];
-	tags: BlobKeyValue[];
-	contentBase64: string;
-	encoding?: string | null;
-	downloadUrl?: string | null;
-};
+type BlobKeyValue = TechAdminBlobStorageExplorerContainerBlobKeyValueFieldsFragment;
+type BlobExplorerFolder = TechAdminBlobStorageExplorerContainerBlobFolderFieldsFragment;
+type BlobExplorerBlob = TechAdminBlobStorageExplorerContainerBlobExplorerBlobFieldsFragment;
+type BlobPreviewContent = TechAdminBlobStorageExplorerContainerBlobContentFieldsFragment;
 
 export type BlobExplorerFilters = {
 	nameContains: string;
@@ -134,9 +116,9 @@ type TableRow =
 			kind: 'blob';
 			name: string;
 			blobName: string;
-			contentType?: string | null | undefined;
+			contentType: string | null;
 			contentLength: number;
-			lastModified?: string | null | undefined;
+			lastModified: string | null;
 			metadata: BlobKeyValue[];
 			tags: BlobKeyValue[];
 	  };
@@ -210,9 +192,9 @@ export const BlobStorageExplorer: React.FC<BlobStorageExplorerProps> = ({
 			kind: 'blob' as const,
 			name: blob.name,
 			blobName: blob.blobName,
-			contentType: blob.contentType,
+			contentType: blob.contentType ?? null,
 			contentLength: blob.contentLength,
-			lastModified: blob.lastModified,
+			lastModified: blob.lastModified ?? null,
 			metadata: blob.metadata,
 			tags: blob.tags,
 		})),

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/blob-storage-explorer.tsx
@@ -2,7 +2,7 @@ import { CloudServerOutlined, DownloadOutlined, EyeOutlined, FolderOutlined, Rel
 import type { TableColumnsType } from 'antd';
 import { Breadcrumb, Button, Input, Modal, Select, Space, Table, Tag, Typography } from 'antd';
 import type React from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -161,6 +161,10 @@ export const BlobStorageExplorer: React.FC<BlobStorageExplorerProps> = ({
 	onClosePreview,
 }) => {
 	const [draftFilters, setDraftFilters] = useState(filters);
+
+	useEffect(() => {
+		setDraftFilters(filters);
+	}, [filters]);
 
 	const breadcrumbItems = useMemo(() => {
 		const segments = prefix.split('/').filter(Boolean);
@@ -386,6 +390,7 @@ export const BlobStorageExplorer: React.FC<BlobStorageExplorerProps> = ({
 				<Button
 					type="primary"
 					size="large"
+					disabled={!selectedContainer}
 					onClick={() => onApplyFilters(draftFilters)}
 				>
 					Apply filters

--- a/packages/ocom/ui-staff-route-tech-admin/src/components/database-explorer.test.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/components/database-explorer.test.tsx
@@ -49,11 +49,11 @@ test('opens full JSON modal from action button', () => {
 		/>,
 	);
 
-	fireEvent.click(screen.getByLabelText('Open JSON modal for 1'));
+	fireEvent.click(screen.getAllByLabelText('Open JSON modal for 1')[0]);
 
 	expect(screen.getByText('Full JSON')).toBeTruthy();
-	expect(screen.getByText(/"Alice"/)).toBeTruthy();
-	expect(screen.getByText('string')).toBeTruthy();
+	expect(screen.getAllByText(/"Alice"/).length).toBeGreaterThan(0);
+	expect(screen.getAllByText('string').length).toBeGreaterThan(0);
 });
 
 test('copies json when clipboard icon is clicked', () => {
@@ -73,7 +73,7 @@ test('copies json when clipboard icon is clicked', () => {
 		/>,
 	);
 
-	fireEvent.click(screen.getByLabelText('Copy JSON for 1'));
+	fireEvent.click(screen.getAllByLabelText('Copy JSON for 1')[0]);
 
 	expect(writeTextMock).toHaveBeenCalledWith('{"name":"Alice","age":30}');
 });

--- a/packages/ocom/ui-staff-route-tech-admin/src/index.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/index.tsx
@@ -1,7 +1,8 @@
 import type React from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { SectionLayout } from './section-layout.tsx';
+import { BlobStorageExplorerPage } from './pages/blob-storage-explorer.tsx';
 import { DatabaseExplorerPage } from './pages/database-explorer.tsx';
+import { SectionLayout } from './section-layout.tsx';
 
 export const Root: React.FC = () => {
 	return (
@@ -13,6 +14,10 @@ export const Root: React.FC = () => {
 				<Route
 					path="database-explorer"
 					element={<DatabaseExplorerPage />}
+				/>
+				<Route
+					path="blob-storage-explorer"
+					element={<BlobStorageExplorerPage />}
 				/>
 			</Route>
 		</Routes>

--- a/packages/ocom/ui-staff-route-tech-admin/src/pages/blob-storage-explorer.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/pages/blob-storage-explorer.tsx
@@ -1,0 +1,19 @@
+import { RequireRole, StaffAppRoles, SubPageLayout } from '@ocom/ui-staff-shared';
+import type React from 'react';
+import { BlobStorageExplorerContainer } from '../components/blob-storage-explorer.container.tsx';
+
+export const BlobStorageExplorerPage: React.FC = () => {
+	return (
+		<RequireRole
+			roles={[StaffAppRoles.TechAdmin]}
+			permKey="canViewBlobExplorer"
+		>
+			<SubPageLayout
+				fixedHeader={false}
+				header={<div style={{ padding: '16px 24px', fontWeight: 700, fontSize: 18 }}>Blob Storage Explorer</div>}
+			>
+				<BlobStorageExplorerContainer />
+			</SubPageLayout>
+		</RequireRole>
+	);
+};

--- a/packages/ocom/ui-staff-route-tech-admin/src/section-layout.tsx
+++ b/packages/ocom/ui-staff-route-tech-admin/src/section-layout.tsx
@@ -1,4 +1,4 @@
-import { DashboardOutlined, ToolOutlined } from '@ant-design/icons';
+import { CloudServerOutlined, DashboardOutlined, ToolOutlined } from '@ant-design/icons';
 import { type SectionLayoutProps, SectionLayout as SharedSectionLayout, type StaffAuth } from '@ocom/ui-staff-shared';
 import type React from 'react';
 export const SectionLayout: React.FC = () => {
@@ -6,6 +6,12 @@ export const SectionLayout: React.FC = () => {
 		const auth = member as StaffAuth | undefined;
 		const perms = auth?.permissions;
 		return perms?.canManageTechAdmin === true || perms?.canViewDatabaseDocuments === true;
+	};
+
+	const hasBlobExplorerAccess = (member: unknown): boolean => {
+		const auth = member as StaffAuth | undefined;
+		const perms = auth?.permissions;
+		return perms?.canManageTechAdmin === true || perms?.canViewBlobExplorer === true;
 	};
 
 	const pageLayouts: SectionLayoutProps['pageLayouts'] = [
@@ -23,6 +29,14 @@ export const SectionLayout: React.FC = () => {
 			id: 'database-explorer',
 			parent: 'tech',
 			hasPermissions: hasDatabaseExplorerAccess,
+		},
+		{
+			path: '/staff/tech/blob-storage-explorer',
+			title: 'Blob Storage Explorer',
+			icon: <CloudServerOutlined />,
+			id: 'blob-storage-explorer',
+			parent: 'tech',
+			hasPermissions: hasBlobExplorerAccess,
 		},
 	];
 

--- a/packages/ocom/ui-staff-shared/src/require-role.tsx
+++ b/packages/ocom/ui-staff-shared/src/require-role.tsx
@@ -37,6 +37,7 @@ const STAFF_USER_CURRENT_QUERY = gql`
 					techAdminPermissions {
 						canManageTechAdmin
 						canViewDatabaseDocuments
+						canViewBlobExplorer
 					}
 				}
 			}
@@ -52,7 +53,7 @@ interface StaffUserCurrentQueryResult {
 				userPermissions: { canManageUsers: boolean; canAssignStaffRoles: boolean; canViewStaffUsers: boolean };
 				staffRolePermissions: { canViewRoles: boolean; canAddRole: boolean; canEditRole: boolean; canRemoveRole: boolean };
 				financePermissions: { canManageFinance: boolean };
-				techAdminPermissions: { canManageTechAdmin: boolean; canViewDatabaseDocuments: boolean };
+				techAdminPermissions: { canManageTechAdmin: boolean; canViewDatabaseDocuments: boolean; canViewBlobExplorer: boolean };
 			};
 		};
 	};
@@ -80,6 +81,7 @@ export const RequireRole: FC<RequireRoleProps> = ({ roles, permKey, children }) 
 				canManageFinance: rolePermissions.financePermissions.canManageFinance,
 				canManageTechAdmin,
 				canViewDatabaseDocuments: rolePermissions.techAdminPermissions.canViewDatabaseDocuments || canManageTechAdmin,
+				canViewBlobExplorer: rolePermissions.techAdminPermissions.canViewBlobExplorer || canManageTechAdmin,
 				canViewRoles: rolePermissions.staffRolePermissions.canViewRoles,
 				canAddRole: rolePermissions.staffRolePermissions.canAddRole,
 				canEditRole: rolePermissions.staffRolePermissions.canEditRole,

--- a/packages/ocom/ui-staff-shared/src/section-layout.tsx
+++ b/packages/ocom/ui-staff-shared/src/section-layout.tsx
@@ -81,14 +81,14 @@ export const SectionLayout: React.FC<SectionLayoutProps> = (props) => {
 	const canManageFinance = perms?.canManageFinance === true;
 	const canManageTechAdmin = perms?.canManageTechAdmin === true;
 	const canViewDatabaseDocuments = perms?.canViewDatabaseDocuments === true;
-	const canAccessTechAdmin = canManageTechAdmin || canViewDatabaseDocuments;
+	const canViewBlobExplorer = perms?.canViewBlobExplorer === true;
+	const canAccessTechAdmin = canManageTechAdmin || canViewDatabaseDocuments || canViewBlobExplorer;
 	const canViewRoles = perms?.canViewRoles === true;
 	const canAddRole = perms?.canAddRole === true;
 	const canEditRole = perms?.canEditRole === true;
 	const canRemoveRole = perms?.canRemoveRole === true;
 	const nestedParentProps = canManageCommunities ? { parent: 'ROOT' as const } : {};
-	const canAccessUserManagement =
-		canManageUsers || canAssignStaffRoles || canViewStaffUsers || canManageStaffRolesAndPermissions || canViewRoles || canAddRole || canEditRole || canRemoveRole || canManageTechAdmin;
+	const canAccessUserManagement = canManageUsers || canAssignStaffRoles || canViewStaffUsers || canManageStaffRolesAndPermissions || canViewRoles || canAddRole || canEditRole || canRemoveRole || canManageTechAdmin;
 
 	// Construct default page layouts ensuring a ROOT entry always exists so MenuComponent renders.
 	// If Communities is allowed, keep the historic behaviour: Communities is ROOT and others are its children.

--- a/packages/ocom/ui-staff-shared/src/staff-route-shell.tsx
+++ b/packages/ocom/ui-staff-shared/src/staff-route-shell.tsx
@@ -23,6 +23,7 @@ export type StaffAuth = {
 		canManageFinance?: boolean;
 		canManageTechAdmin?: boolean;
 		canViewDatabaseDocuments?: boolean;
+		canViewBlobExplorer?: boolean;
 		canViewRoles?: boolean;
 		canAddRole?: boolean;
 		canEditRole?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,7 @@ catalogs:
       version: 4.1.10
 
 overrides:
+  '@apollo/protobufjs': ^1.2.8
   '@vitest/browser': 4.1.10
   '@vitest/browser-playwright': 4.1.10
   happy-dom: 20.10.1
@@ -136,7 +137,8 @@ overrides:
   jiti: 2.6.1
   rollup: ^4.59.0
   '@ant-design/pro-layout>path-to-regexp': ^8.4.0
-  brace-expansion: 5.0.8
+  brace-expansion: ^5.0.9
+  browserslist: ^4.28.7
   diff@4.0.2: 4.0.4
   '@protobufjs/codegen': 2.0.5
   '@protobufjs/utf8': 1.1.1
@@ -152,6 +154,7 @@ overrides:
   ajv@^6: 6.14.0
   lodash: 4.18.1
   lodash-es: 4.18.1
+  nanoid: ^3.3.18
   node-forge: ^1.4.0
   node-forge@<1.3.2: '>=1.3.2'
   picomatch: ^4.0.4
@@ -167,11 +170,11 @@ overrides:
   postcss: ^8.5.18
   protobufjs: 7.6.5
   ip-address: ^10.2.1
-  fast-uri: ^4.1.1
+  fast-uri: ^4.1.3
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@babel/core': ^7.29.6
-  js-yaml: 4.3.0
-  js-yaml@3.14.2: 3.15.0
+  js-yaml: ^4.3.1
+  js-yaml@3.14.2: 3.15.1
   shell-quote@<1.8.4: 1.8.4
   '@opentelemetry/exporter-prometheus@0.57.2': 0.217.0
   '@opentelemetry/core@2.7.1': 2.8.0
@@ -3089,8 +3092,8 @@ packages:
       subscriptions-transport-ws:
         optional: true
 
-  '@apollo/protobufjs@1.2.7':
-    resolution: {integrity: sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==}
+  '@apollo/protobufjs@1.2.8':
+    resolution: {integrity: sha512-r7xNeUqZX+eBBEmyvaPw0/cSz6zgf5jdH8mjUz8ynKpNs/GU7vi2T7sNcZINk2ZID7wwjG91FCgdpCrQuJ8rzA==}
     hasBin: true
 
   '@apollo/server-gateway-interface@2.0.0':
@@ -6179,14 +6182,8 @@ packages:
   '@protobufjs/codegen@2.0.5':
     resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
-
   '@protobufjs/eventemitter@1.1.1':
     resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
-
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
 
   '@protobufjs/fetch@1.1.1':
     resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
@@ -7871,8 +7868,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.0:
-    resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -7927,8 +7924,8 @@ packages:
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -7961,8 +7958,8 @@ packages:
   browserify-zlib@0.2.0:
     resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -8086,6 +8083,9 @@ packages:
 
   caniuse-lite@1.0.30001777:
     resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
@@ -8882,8 +8882,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.307:
-    resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
+  electron-to-chromium@1.5.415:
+    resolution: {integrity: sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==}
 
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
@@ -9150,8 +9150,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.3:
+    resolution: {integrity: sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -10231,12 +10231,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsbi@4.3.2:
@@ -11122,8 +11122,8 @@ packages:
     resolution: {integrity: sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==}
     engines: {node: '>=12.0.0'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -11192,8 +11192,9 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
 
   node-stdlib-browser@1.3.1:
     resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
@@ -13623,11 +13624,11 @@ packages:
     resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
     engines: {node: '>=4'}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: ^4.28.7
 
   update-notifier@6.0.2:
     resolution: {integrity: sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==}
@@ -14467,13 +14468,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@apollo/protobufjs@1.2.7':
+  '@apollo/protobufjs@1.2.8':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
       '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
       '@protobufjs/inquire': 1.1.1
       '@protobufjs/path': 1.1.2
@@ -14519,7 +14520,7 @@ snapshots:
 
   '@apollo/usage-reporting-protobuf@4.1.1':
     dependencies:
-      '@apollo/protobufjs': 1.2.7
+      '@apollo/protobufjs': 1.2.8
 
   '@apollo/utils.createhash@3.0.1':
     dependencies:
@@ -15002,7 +15003,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -16572,7 +16573,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -17018,7 +17019,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.1(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       fs-extra: 11.3.2
       joi: 17.13.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -17043,7 +17044,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3
       jiti: 2.6.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -17619,7 +17620,7 @@ snapshots:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       jose: 5.10.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       scuid: 1.1.0
       tslib: 2.8.1
@@ -18725,14 +18726,7 @@ snapshots:
 
   '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
-
   '@protobufjs/eventemitter@1.1.1': {}
-
-  '@protobufjs/fetch@1.1.0':
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.1
 
   '@protobufjs/fetch@1.1.1':
     dependencies:
@@ -20350,7 +20344,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -20607,7 +20601,7 @@ snapshots:
 
   autoprefixer@10.4.22(postcss@8.5.25):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001777
       fraction.js: 5.3.4
       normalize-range: 0.1.2
@@ -20717,7 +20711,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.0: {}
+  baseline-browser-mapping@2.11.19: {}
 
   basic-auth@2.0.1:
     dependencies:
@@ -20795,7 +20789,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -20853,13 +20847,13 @@ snapshots:
     dependencies:
       pako: 1.0.11
 
-  browserslist@4.28.1:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001777
-      electron-to-chromium: 1.5.307
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.415
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
   bser@2.1.1:
     dependencies:
@@ -20977,12 +20971,14 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001777
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001777: {}
+
+  caniuse-lite@1.0.30001810: {}
 
   capital-case@1.0.4:
     dependencies:
@@ -21329,7 +21325,7 @@ snapshots:
 
   core-js-compat@3.47.0:
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
 
   core-js@3.47.0: {}
 
@@ -21343,7 +21339,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -21491,7 +21487,7 @@ snapshots:
   cssnano-preset-advanced@6.1.2(postcss@8.5.25):
     dependencies:
       autoprefixer: 10.4.22(postcss@8.5.25)
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       cssnano-preset-default: 6.1.2(postcss@8.5.25)
       postcss: 8.5.25
       postcss-discard-unused: 6.0.5(postcss@8.5.25)
@@ -21501,7 +21497,7 @@ snapshots:
 
   cssnano-preset-default@6.1.2(postcss@8.5.25):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       css-declaration-sorter: 7.3.0(postcss@8.5.25)
       cssnano-utils: 4.0.2(postcss@8.5.25)
       postcss: 8.5.25
@@ -21793,7 +21789,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.307: {}
+  electron-to-chromium@1.5.415: {}
 
   elliptic@6.6.1:
     dependencies:
@@ -22177,7 +22173,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.3: {}
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -22632,7 +22628,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -23396,12 +23392,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -23529,7 +23525,7 @@ snapshots:
       fast-glob: 3.3.3
       formatly: 0.3.0
       jiti: 2.6.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimist: 1.2.8
       oxc-resolver: 11.14.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       picocolors: 1.1.1
@@ -24376,15 +24372,15 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
@@ -24590,7 +24586,7 @@ snapshots:
     dependencies:
       lru-cache: 7.18.3
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   native-duplexpair@1.0.0: {}
 
@@ -24646,7 +24642,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.27: {}
+  node-releases@2.0.53: {}
 
   node-stdlib-browser@1.3.1:
     dependencies:
@@ -25224,7 +25220,7 @@ snapshots:
 
   postcss-colormin@6.1.0(postcss@8.5.25):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.5.25
@@ -25232,7 +25228,7 @@ snapshots:
 
   postcss-convert-values@6.1.0(postcss@8.5.25):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
 
@@ -25377,7 +25373,7 @@ snapshots:
 
   postcss-merge-rules@6.1.1(postcss@8.5.25):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       cssnano-utils: 4.0.2(postcss@8.5.25)
       postcss: 8.5.25
@@ -25397,7 +25393,7 @@ snapshots:
 
   postcss-minify-params@6.1.0(postcss@8.5.25):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       cssnano-utils: 4.0.2(postcss@8.5.25)
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
@@ -25471,7 +25467,7 @@ snapshots:
 
   postcss-normalize-unicode@6.1.0(postcss@8.5.25):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
 
@@ -25548,7 +25544,7 @@ snapshots:
       '@csstools/postcss-trigonometric-functions': 4.0.9(postcss@8.5.25)
       '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.25)
       autoprefixer: 10.4.22(postcss@8.5.25)
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       css-blank-pseudo: 7.0.1(postcss@8.5.25)
       css-has-pseudo: 7.0.3(postcss@8.5.25)
       css-prefers-color-scheme: 10.0.0(postcss@8.5.25)
@@ -25592,7 +25588,7 @@ snapshots:
 
   postcss-reduce-initial@6.1.0(postcss@8.5.25):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       postcss: 8.5.25
 
@@ -25644,7 +25640,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -26921,7 +26917,7 @@ snapshots:
 
   stylehacks@6.1.1(postcss@8.5.25):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       postcss: 8.5.25
       postcss-selector-parser: 6.1.2
 
@@ -27420,9 +27416,9 @@ snapshots:
 
   upath@2.0.1: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -27781,7 +27777,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.20.0
       es-module-lexer: 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,7 +170,7 @@ overrides:
   '@apollo/protobufjs': 1.2.8
   protobufjs: 7.6.5
   ip-address: ^10.2.1
-  fast-uri: 4.1.2
+  fast-uri: ^4.1.3
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@babel/core': ^7.29.6
   js-yaml: 4.3.1
@@ -9172,8 +9172,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.3:
+    resolution: {integrity: sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -20339,7 +20339,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 4.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -22168,7 +22168,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.3: {}
 
   fast-xml-builder@1.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,7 @@ catalogs:
 overrides:
   '@vitest/browser': 4.1.10
   '@vitest/browser-playwright': 4.1.10
+  browserslist: 4.28.7
   happy-dom: 20.10.1
   axios: 1.19.0
   body-parser: 2.3.0
@@ -165,15 +166,15 @@ overrides:
   playwright-core: 1.59.0
   playwright: 1.59.0
   postcss: 8.5.23
-  nanoid@^3: 3.3.17
+  nanoid@^3: 3.3.18
   '@apollo/protobufjs': 1.2.8
   protobufjs: 7.6.5
   ip-address: ^10.2.1
   fast-uri: 4.1.2
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@babel/core': ^7.29.6
-  js-yaml: 4.3.0
-  js-yaml@3.14.2: 3.15.0
+  js-yaml: 4.3.1
+  js-yaml@3.14.2: 3.15.1
   shell-quote@<1.8.4: 1.8.4
   '@opentelemetry/exporter-prometheus@0.57.2': 0.217.0
   '@opentelemetry/core@2.7.1': 2.8.0
@@ -7889,8 +7890,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.0:
-    resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
+  baseline-browser-mapping@2.11.18:
+    resolution: {integrity: sha512-1iEmLEYSiE1SeBoAfPo/Mnx3PzfzHUkDK61ASkCpuk3YXugYLH5DYK1SzqV55F8FMI6s0F+/tCP7Polz1QRjxw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -7979,8 +7980,8 @@ packages:
   browserify-zlib@0.2.0:
     resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.7:
+    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -8104,6 +8105,9 @@ packages:
 
   caniuse-lite@1.0.30001777:
     resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
+
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
@@ -8900,8 +8904,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.307:
-    resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
+  electron-to-chromium@1.5.412:
+    resolution: {integrity: sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA==}
 
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
@@ -10249,12 +10253,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsbi@4.3.2:
@@ -11113,8 +11117,8 @@ packages:
     resolution: {integrity: sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==}
     engines: {node: '>=12.0.0'}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -11183,8 +11187,9 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
 
   node-stdlib-browser@1.3.1:
     resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
@@ -13618,7 +13623,7 @@ packages:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.7
 
   update-notifier@6.0.2:
     resolution: {integrity: sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==}
@@ -14993,7 +14998,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -16563,7 +16568,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -17009,7 +17014,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.1(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       fs-extra: 11.3.2
       joi: 17.13.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -17034,7 +17039,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3
       jiti: 2.6.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -17610,7 +17615,7 @@ snapshots:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       jose: 5.10.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       scuid: 1.1.0
       tslib: 2.8.1
@@ -20591,7 +20596,7 @@ snapshots:
 
   autoprefixer@10.4.22(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       caniuse-lite: 1.0.30001777
       fraction.js: 5.3.4
       normalize-range: 0.1.2
@@ -20701,7 +20706,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.0: {}
+  baseline-browser-mapping@2.11.18: {}
 
   basic-auth@2.0.1:
     dependencies:
@@ -20837,13 +20842,13 @@ snapshots:
     dependencies:
       pako: 1.0.11
 
-  browserslist@4.28.1:
+  browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001777
-      electron-to-chromium: 1.5.307
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      baseline-browser-mapping: 2.11.18
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.412
+      node-releases: 2.0.53
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   bser@2.1.1:
     dependencies:
@@ -20961,12 +20966,14 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       caniuse-lite: 1.0.30001777
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001777: {}
+
+  caniuse-lite@1.0.30001809: {}
 
   capital-case@1.0.4:
     dependencies:
@@ -21313,7 +21320,7 @@ snapshots:
 
   core-js-compat@3.47.0:
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
 
   core-js@3.47.0: {}
 
@@ -21327,7 +21334,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -21475,7 +21482,7 @@ snapshots:
   cssnano-preset-advanced@6.1.2(postcss@8.5.23):
     dependencies:
       autoprefixer: 10.4.22(postcss@8.5.23)
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       cssnano-preset-default: 6.1.2(postcss@8.5.23)
       postcss: 8.5.23
       postcss-discard-unused: 6.0.5(postcss@8.5.23)
@@ -21485,7 +21492,7 @@ snapshots:
 
   cssnano-preset-default@6.1.2(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       css-declaration-sorter: 7.3.0(postcss@8.5.23)
       cssnano-utils: 4.0.2(postcss@8.5.23)
       postcss: 8.5.23
@@ -21777,7 +21784,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.307: {}
+  electron-to-chromium@1.5.412: {}
 
   elliptic@6.6.1:
     dependencies:
@@ -22616,7 +22623,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -23380,12 +23387,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -23513,7 +23520,7 @@ snapshots:
       fast-glob: 3.3.3
       formatly: 0.3.0
       jiti: 2.6.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimist: 1.2.8
       oxc-resolver: 11.14.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       picocolors: 1.1.1
@@ -24568,7 +24575,7 @@ snapshots:
     dependencies:
       lru-cache: 7.18.3
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   native-duplexpair@1.0.0: {}
 
@@ -24624,7 +24631,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.27: {}
+  node-releases@2.0.53: {}
 
   node-stdlib-browser@1.3.1:
     dependencies:
@@ -25202,7 +25209,7 @@ snapshots:
 
   postcss-colormin@6.1.0(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.5.23
@@ -25210,7 +25217,7 @@ snapshots:
 
   postcss-convert-values@6.1.0(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
@@ -25355,7 +25362,7 @@ snapshots:
 
   postcss-merge-rules@6.1.1(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       caniuse-api: 3.0.0
       cssnano-utils: 4.0.2(postcss@8.5.23)
       postcss: 8.5.23
@@ -25375,7 +25382,7 @@ snapshots:
 
   postcss-minify-params@6.1.0(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       cssnano-utils: 4.0.2(postcss@8.5.23)
       postcss: 8.5.23
       postcss-value-parser: 4.2.0
@@ -25449,7 +25456,7 @@ snapshots:
 
   postcss-normalize-unicode@6.1.0(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
@@ -25526,7 +25533,7 @@ snapshots:
       '@csstools/postcss-trigonometric-functions': 4.0.9(postcss@8.5.23)
       '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.23)
       autoprefixer: 10.4.22(postcss@8.5.23)
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       css-blank-pseudo: 7.0.1(postcss@8.5.23)
       css-has-pseudo: 7.0.3(postcss@8.5.23)
       css-prefers-color-scheme: 10.0.0(postcss@8.5.23)
@@ -25570,7 +25577,7 @@ snapshots:
 
   postcss-reduce-initial@6.1.0(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       caniuse-api: 3.0.0
       postcss: 8.5.23
 
@@ -25622,7 +25629,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -26899,7 +26906,7 @@ snapshots:
 
   stylehacks@6.1.1(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       postcss: 8.5.23
       postcss-selector-parser: 6.1.2
 
@@ -27398,9 +27405,9 @@ snapshots:
 
   upath@2.0.1: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -27759,7 +27766,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.20.0
       es-module-lexer: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,6 +65,8 @@ auditConfig:
     - GHSA-q7rr-3cgh-j5r3
     - GHSA-869p-cjfg-cm3x # jws@4.0.0: Improperly Verifies HMAC Signature (transitive from azurite)
     - GHSA-qwww-vcr4-c8h2 # react-router 7.x: defer upgrade until the react-router-dom v8 migration is completed
+    - GHSA-w3rx-r6r6-pgpr # image-size<=2.0.2: >=2.0.3 listed as patched but version not available on npm registry; latest is 2.0.2 which is being flagged as vulnerable; ignore for now
+    - GHSA-5p2g-fcmc-qvqq # image-size<=2.0.2: same as above
 
 allowBuilds:
   '@apollo/protobufjs': true
@@ -77,6 +79,7 @@ allowBuilds:
   snyk: true
 
 overrides:
+  '@apollo/protobufjs': ^1.2.8
   '@vitest/browser': 4.1.10
   '@vitest/browser-playwright': 4.1.10
   happy-dom: 20.10.1
@@ -88,7 +91,8 @@ overrides:
   jiti: 2.6.1
   rollup: ^4.59.0
   '@ant-design/pro-layout>path-to-regexp': ^8.4.0
-  brace-expansion: 5.0.8
+  brace-expansion: ^5.0.9
+  browserslist: ^4.28.7
   'diff@4.0.2': 4.0.4
   '@protobufjs/codegen': 2.0.5
   '@protobufjs/utf8': 1.1.1
@@ -104,6 +108,7 @@ overrides:
   'ajv@^6': 6.14.0
   lodash: 4.18.1
   lodash-es: 4.18.1
+  nanoid: ^3.3.18
   node-forge: ^1.4.0
   node-forge@<1.3.2: '>=1.3.2'
   picomatch: ^4.0.4
@@ -119,11 +124,11 @@ overrides:
   postcss: ^8.5.18
   protobufjs: 7.6.5
   ip-address: ^10.2.1
-  fast-uri: ^4.1.1
+  fast-uri: ^4.1.3
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@babel/core': ^7.29.6
-  js-yaml: 4.3.0
-  'js-yaml@3.14.2': 3.15.0
+  js-yaml: ^4.3.1
+  'js-yaml@3.14.2': 3.15.1
   'shell-quote@<1.8.4': 1.8.4
   '@opentelemetry/exporter-prometheus@0.57.2': 0.217.0
   '@opentelemetry/core@2.7.1': 2.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,6 +66,8 @@ auditConfig:
     - GHSA-45rx-2jwx-cxfr # @opentelemetry/propagator-jaeger: fix is 2.x; Azure/OTel stack pinned to v1
     - GHSA-chx6-hx7r-mcp5 # react-router: 7.18+ breaks Docusaurus 3.10 matchPath; stay on 7.15.x for now
     - GHSA-qwww-vcr4-c8h2 # react-router RSC CSRF: fix needs react-router 8.x; apps not on RSC mode; stay on 7.15.x
+    - GHSA-w3rx-r6r6-pgpr # image-size<=2.0.2: >=2.0.3 listed as patched but version not available on npm registry; latest is 2.0.2 which is being flagged as vulnerable; ignore for now
+    - GHSA-5p2g-fcmc-qvqq # image-size<=2.0.2: same as above
 
 allowBuilds:
   '@apollo/protobufjs': true
@@ -80,6 +82,7 @@ allowBuilds:
 overrides:
   '@vitest/browser': 4.1.10
   '@vitest/browser-playwright': 4.1.10
+  browserslist: 4.28.7
   happy-dom: 20.10.1
   axios: 1.19.0
   body-parser: 2.3.0
@@ -118,15 +121,15 @@ overrides:
   playwright-core: 1.59.0
   playwright: 1.59.0
   postcss: 8.5.23
-  'nanoid@^3': 3.3.17
+  'nanoid@^3': 3.3.18
   '@apollo/protobufjs': 1.2.8
   protobufjs: 7.6.5
   ip-address: ^10.2.1
   fast-uri: 4.1.2
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@babel/core': ^7.29.6
-  js-yaml: 4.3.0
-  'js-yaml@3.14.2': 3.15.0
+  js-yaml: 4.3.1
+  'js-yaml@3.14.2': 3.15.1
   'shell-quote@<1.8.4': 1.8.4
   '@opentelemetry/exporter-prometheus@0.57.2': 0.217.0
   '@opentelemetry/core@2.7.1': 2.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -125,7 +125,7 @@ overrides:
   '@apollo/protobufjs': 1.2.8
   protobufjs: 7.6.5
   ip-address: ^10.2.1
-  fast-uri: 4.1.2
+  fast-uri: ^4.1.3
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@babel/core': ^7.29.6
   js-yaml: 4.3.1


### PR DESCRIPTION
## Summary by Sourcery

Add a permission-controlled Blob Storage Explorer to Tech Admin and extend blob services and APIs to support scalable browsing, filtering, preview, and download workflows.

New Features:
- Add a permission-gated staff Blob Storage Explorer for browsing containers, navigating virtual folders, filtering blob metadata and tags, paginating results, previewing supported content, and downloading blobs.
- Expose blob container listing, hierarchical exploration, bounded downloads, and read SAS URLs through the blob storage service, application services, and GraphQL API.

Bug Fixes:
- Ensure test server ports are fully released before replacement processes start.
- Make portless route pruning best-effort so stale route locks do not prevent the test proxy from starting.

Enhancements:
- Extend staff permission propagation and Tech Admin routing to support Blob Storage Explorer access.
- Improve process test server cleanup with graceful termination, forced termination, and port availability checks.

Build:
- Use the Azure Functions Core Tools installer task in the monorepo build pipeline.
- Refresh dependency lockfile and package security overrides.

Documentation:
- Document the expanded blob storage operations, hierarchical exploration, metadata and tag support, pagination, and bounded downloads.

Tests:
- Add coverage for blob storage operations, GraphQL authorization and resolvers, Blob Storage Explorer interactions, and process server port cleanup.