### PR TITLE
chore: add debug task for npm configuration before installing function tools to debug npm install -g failure

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -69,3 +69,4 @@ Cellix.initializeInfrastructureServices<ApiContextSpec, ApplicationServices>((se
 	)
 	.registerAzureFunctionHttpHandler('rest', { route: '{communityId}/{role}/{memberId}/{*rest}' }, restHandlerCreator)
 	.startUp();
+    

--- a/build-pipeline/core/monorepo-build-stage.yml
+++ b/build-pipeline/core/monorepo-build-stage.yml
@@ -69,6 +69,22 @@ stages:
         path: '/opt/hostedtoolcache/func'
         cacheHitVar: FUNC_TOOLS_CACHE_HIT
 
+    - task: Bash@3
+      displayName: 'Debug: npm config before func tools install'
+      condition: and(ne(variables.FUNC_TOOLS_CACHE_HIT, 'true'), ne(variables.FUNC_TOOLS_CACHE_HIT, 'inexact'))
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -euxo pipefail
+          echo "Home .npmrc:"
+          cat ~/.npmrc || echo "No ~/.npmrc"
+          echo "Repo .npmrc:"
+          cat .npmrc || echo "No repo .npmrc"
+          echo "Environment:"
+          env | sort
+          echo "npm config list:"
+          npm config list
+
     # Ensure the correct version of function tools are installed.
     # Temporary change to use npm global install due to github repo being restricted
     - task: Bash@3

--- a/readme.md
+++ b/readme.md
@@ -452,4 +452,3 @@ Have feedback? Leave a comment in [CellixJS discussions on GitHub](https://githu
 [![sharethrift contributors](https://contrib.rocks/image?repo=cellixjs/cellixjs)](https://github.com/cellixjs/cellixjs/graphs/contributors)
 
 [⬆ Back to Top](#table-of-contents)
-

--- a/readme.md
+++ b/readme.md
@@ -452,3 +452,4 @@ Have feedback? Leave a comment in [CellixJS discussions on GitHub](https://githu
 [![sharethrift contributors](https://contrib.rocks/image?repo=cellixjs/cellixjs)](https://github.com/cellixjs/cellixjs/graphs/contributors)
 
 [⬆ Back to Top](#table-of-contents)
+


### PR DESCRIPTION
## Summary by Sourcery

Add conditional npm diagnostics to the monorepo build before installing Azure Function tools.

Enhancements:
- Add conditional npm configuration diagnostics before installing Azure Function tools to help investigate global installation failures.

Build:
- Add a build-stage debug task that captures npm configuration, environment variables, and available .npmrc files when the function-tools cache is not usable.